### PR TITLE
chore: adopt DCO contribution verification

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,8 @@ Link the related issue if applicable, for example `Closes #123`.
 
 ## Checklist
 
+- [ ] I added a `Signed-off-by` line to each commit (`git commit -s`)
+  per the [DCO](https://developercertificate.org/).
 - [ ] I added focused tests when behavior changed and ran the relevant checks
   locally.
 - [ ] I updated any affected documentation and configuration examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,18 @@ For a local snapshot consumed by another build, run
 `./gradlew publishToMavenLocal` and add `mavenLocal()` only in that local
 consumer.
 
+## Developer Certificate of Origin
+
+All commits must include a `Signed-off-by` trailer at the end of the commit
+message to indicate that the contributor agrees to the
+[Developer Certificate of Origin](https://developercertificate.org/).
+
+Use the following command to add the trailer automatically:
+
+```bash
+git commit -s
+```
+
 ## Commit Messages
 
 Use Conventional Commits for commit messages:


### PR DESCRIPTION
## Summary

Add DCO sign-off documentation, a pull request checklist reminder, and DCO validation configuration.
This PR also verifies that the DCO status check runs successfully.

## Related Issue

Not applicable.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.