### PR TITLE
feat: diagnose privacy configuration typos safely

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,28 @@ cost, concurrency, and side-effect budgets in the application or orchestration
 framework. The remaining output limits bound only the stream content this
 library must inspect or retain to enforce its privacy boundary.
 
+### Configuration typo diagnostics
+
+The base starter logs a warning for likely misspellings in the fixed property
+surface owned by this library. This diagnostic auto-configuration is independent
+of `spring.ai.privacy.enabled`, so it can also report a likely misspelling of the
+global switch when the privacy auto-configuration remains inactive. Warnings do
+not fail application startup. The diagnostic remains eager when the host enables
+Spring Boot's global lazy initialization and recognizes relaxed operating-system
+environment variable names for dashed properties. If a host-provided property
+source cannot safely enumerate its property names, diagnostics skip only that
+source and continue without logging the source or its exception.
+
+Diagnostics are deliberately narrow. They cover high-confidence typos of the
+global switch and fixed fields below `output`, `response-inspection`, `analysis`,
+`regex`, and `tools`. They do not inspect provider or application extension
+subtrees. Dynamic keys below `analysis.provider-minimum-scores`,
+`analysis.entity-aliases`, and `tools.disclosures` are accepted without warning;
+provider-owned maps such as Presidio `headers` and OpenNLP `entity-models` are
+also outside the base diagnostic scope. Warning messages contain only the fixed
+property path and a canonical suggestion, never a configured value, credential,
+or dynamic map key.
+
 ## Detection and Resolution
 
 Analyzers return source ranges as evidence. Core applies aliases, allowlists,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,27 +94,25 @@ cost, concurrency, and side-effect budgets in the application or orchestration
 framework. The remaining output limits bound only the stream content this
 library must inspect or retain to enforce its privacy boundary.
 
-### Configuration typo diagnostics
+### Configuration property diagnostics
 
-The base starter logs a warning for likely misspellings in the fixed property
-surface owned by this library. This diagnostic auto-configuration is independent
-of `spring.ai.privacy.enabled`, so it can also report a likely misspelling of the
-global switch when the privacy auto-configuration remains inactive. Warnings do
-not fail application startup. The diagnostic remains eager when the host enables
-Spring Boot's global lazy initialization and recognizes relaxed operating-system
-environment variable names for dashed properties. If a host-provided property
-source cannot safely enumerate its property names, diagnostics skip only that
-source and continue without logging the source or its exception.
+The base starter logs non-blocking warnings for unrecognized names in the fixed
+`spring.ai.privacy` properties defined by this library. Diagnostics run
+independently of `spring.ai.privacy.enabled`, so they can report a likely
+misspelling of the top-level `enabled` property even when privacy
+auto-configuration does not activate.
 
-Diagnostics are deliberately narrow. They cover high-confidence typos of the
-global switch and fixed fields below `output`, `response-inspection`, `analysis`,
-`regex`, and `tools`. They do not inspect provider or application extension
-subtrees. Dynamic keys below `analysis.provider-minimum-scores`,
-`analysis.entity-aliases`, and `tools.disclosures` are accepted without warning;
-provider-owned maps such as Presidio `headers` and OpenNLP `entity-models` are
-also outside the base diagnostic scope. Warning messages contain only the fixed
-property path and a canonical suggestion, never a configured value, credential,
-or dynamic map key.
+At the top level, diagnostics check only likely misspellings of `enabled`, leaving
+provider and application extension names untouched. Within the fixed `output`,
+`response-inspection`, `analysis`, `regex`, and `tools` areas, every unrecognized
+property name produces a warning. Dynamic keys below
+`analysis.provider-minimum-scores`, `analysis.entity-aliases`, and
+`tools.disclosures` are accepted. Entries in the `analysis.included-entity-types`
+and `analysis.supplemental-providers` lists are not treated as property names.
+Provider-owned maps such as Presidio `headers` and OpenNLP `entity-models` are also
+outside the diagnostic scope. When there is a single likely supported property,
+the warning suggests it. Diagnostics never log configuration values, credentials,
+or dynamic map keys, and they never prevent application startup.
 
 ## Detection and Resolution
 

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -3,7 +3,7 @@
 [English](../configuration.md) | [한국어](configuration.md)
 
 <!-- i18n-source: docs/configuration.md -->
-<!-- i18n-source-sha256: 64e191d0f7a6220669d056bc331579a357157c27f01653acafceb99f630cce98 -->
+<!-- i18n-source-sha256: 2287479f14a50f8005a0eed34426a52a4ae8d73cf243e491c7c196763267c07f -->
 
 이 문서는 Spring AI Privacy Guardrails를 사용하는 애플리케이션을 위한 전체
 참고 문서입니다. Base starter는 `core`와 Spring AI 경계를 제공하며, provider
@@ -96,6 +96,26 @@ Starter 의존성만 추가하면 모든 개인정보 보호 자동 설정은 �
 애플리케이션이나 orchestration framework에서 설정하세요. 나머지 출력 상한은
 라이브러리가 개인정보 보호 경계를 집행하기 위해 검사하거나 보존해야 하는
 스트림 콘텐츠만 제한합니다.
+
+### 설정 오타 진단
+
+Base starter는 이 라이브러리가 소유한 고정 설정에서 오타 가능성이 높은 이름을
+발견하면 경고를 기록합니다. 진단 자동 설정은 `spring.ai.privacy.enabled`와 독립적으로
+실행되므로, 전역 switch의 오타 때문에 개인정보 보호 자동 설정이 비활성 상태로
+남는 경우도 알릴 수 있습니다. 이 경고는 애플리케이션 시작을 실패시키지 않습니다.
+호스트가 Spring Boot의 전역 lazy initialization을 활성화해도 진단은 시작 시 실행되며,
+dash가 포함된 설정의 완화된 운영체제 환경변수 이름도 인식합니다. 호스트가 제공한
+property source가 property 이름을 안전하게 열거하지 못하면, 그 source의 진단만
+건너뛰고 source나 예외를 로그에 남기지 않은 채 나머지 진단을 계속합니다.
+
+진단 범위는 의도적으로 좁습니다. 전역 switch와 `output`, `response-inspection`,
+`analysis`, `regex`, `tools` 아래 고정 필드의 가능성이 높은 오타만 다룹니다.
+Provider 또는 애플리케이션 확장 subtree는 검사하지 않습니다.
+`analysis.provider-minimum-scores`, `analysis.entity-aliases`, `tools.disclosures`
+아래 동적 key는 경고 없이 허용하며, Presidio `headers`와 OpenNLP `entity-models`
+같은 provider 소유 map도 base 진단 범위 밖입니다. 경고 메시지는 고정 property
+경로와 정규 이름 제안만 포함하며 설정값, credential 또는 동적 map key를 포함하지
+않습니다.
 
 ## 탐지와 해석
 

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -3,7 +3,7 @@
 [English](../configuration.md) | [한국어](configuration.md)
 
 <!-- i18n-source: docs/configuration.md -->
-<!-- i18n-source-sha256: 2287479f14a50f8005a0eed34426a52a4ae8d73cf243e491c7c196763267c07f -->
+<!-- i18n-source-sha256: e5be5c401cfc37a587d3dea678e1e6693533d9b71dd8bb5bbbdfa36fdc49158d -->
 
 이 문서는 Spring AI Privacy Guardrails를 사용하는 애플리케이션을 위한 전체
 참고 문서입니다. Base starter는 `core`와 Spring AI 경계를 제공하며, provider
@@ -97,25 +97,23 @@ Starter 의존성만 추가하면 모든 개인정보 보호 자동 설정은 �
 라이브러리가 개인정보 보호 경계를 집행하기 위해 검사하거나 보존해야 하는
 스트림 콘텐츠만 제한합니다.
 
-### 설정 오타 진단
+### 설정 프로퍼티 진단
 
-Base starter는 이 라이브러리가 소유한 고정 설정에서 오타 가능성이 높은 이름을
-발견하면 경고를 기록합니다. 진단 자동 설정은 `spring.ai.privacy.enabled`와 독립적으로
-실행되므로, 전역 switch의 오타 때문에 개인정보 보호 자동 설정이 비활성 상태로
-남는 경우도 알릴 수 있습니다. 이 경고는 애플리케이션 시작을 실패시키지 않습니다.
-호스트가 Spring Boot의 전역 lazy initialization을 활성화해도 진단은 시작 시 실행되며,
-dash가 포함된 설정의 완화된 운영체제 환경변수 이름도 인식합니다. 호스트가 제공한
-property source가 property 이름을 안전하게 열거하지 못하면, 그 source의 진단만
-건너뛰고 source나 예외를 로그에 남기지 않은 채 나머지 진단을 계속합니다.
+Base starter는 이 라이브러리가 정의한 고정 `spring.ai.privacy` 프로퍼티에서 인식할 수
+없는 이름을 발견하면 애플리케이션을 차단하지 않는 경고를 기록합니다. 진단은
+`spring.ai.privacy.enabled`와 독립적으로 실행되므로, 최상위 `enabled`의 오타로 인해
+개인정보 보호 자동 설정이 활성화되지 않은 경우에도 이를 알릴 수 있습니다.
 
-진단 범위는 의도적으로 좁습니다. 전역 switch와 `output`, `response-inspection`,
-`analysis`, `regex`, `tools` 아래 고정 필드의 가능성이 높은 오타만 다룹니다.
-Provider 또는 애플리케이션 확장 subtree는 검사하지 않습니다.
-`analysis.provider-minimum-scores`, `analysis.entity-aliases`, `tools.disclosures`
-아래 동적 key는 경고 없이 허용하며, Presidio `headers`와 OpenNLP `entity-models`
-같은 provider 소유 map도 base 진단 범위 밖입니다. 경고 메시지는 고정 property
-경로와 정규 이름 제안만 포함하며 설정값, credential 또는 동적 map key를 포함하지
-않습니다.
+최상위에서는 provider와 애플리케이션 확장 이름에 영향을 주지 않도록 `enabled`의 오타
+가능성이 높은 이름만 검사합니다. 고정 `output`, `response-inspection`, `analysis`,
+`regex`, `tools` 하위 영역에서는 인식할 수 없는 모든 프로퍼티 이름에 경고합니다.
+`analysis.provider-minimum-scores`, `analysis.entity-aliases`, `tools.disclosures` 아래의
+동적 키는 허용합니다. `analysis.included-entity-types`와
+`analysis.supplemental-providers`의 목록 항목도 프로퍼티 이름으로 진단하지 않습니다.
+Presidio의 `headers`와 OpenNLP의 `entity-models`처럼 provider가 소유한 맵도 진단
+범위에서 제외합니다. 지원되는 프로퍼티 중 유력한 후보가 하나뿐이면 경고에 올바른
+이름을 제안합니다. 진단은 설정값, 자격 증명 또는 동적 맵 키를 로그에 남기지 않으며
+애플리케이션 시작을 막지 않습니다.
 
 ## 탐지와 해석
 

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationDiagnosticsAutoConfiguration.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationDiagnosticsAutoConfiguration.java
@@ -1,0 +1,22 @@
+package io.github.ultramancode.springai.privacy.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
+
+/** Auto-configures non-blocking diagnostics for likely privacy property typos. */
+@AutoConfiguration(before = PrivacyGuardrailsAutoConfiguration.class)
+public class PrivacyConfigurationDiagnosticsAutoConfiguration {
+
+    @Bean
+    @Lazy(false)
+    @ConditionalOnMissingBean(name = "privacyConfigurationPropertyDiagnostics")
+    PrivacyConfigurationPropertyDiagnostics privacyConfigurationPropertyDiagnostics(
+            Environment environment
+    ) {
+        return new PrivacyConfigurationPropertyDiagnostics(environment);
+    }
+
+}

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationDiagnosticsAutoConfiguration.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationDiagnosticsAutoConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 
-/** Auto-configures non-blocking diagnostics for likely privacy property typos. */
+/** Auto-configures non-blocking diagnostics for fixed privacy configuration properties. */
 @AutoConfiguration(before = PrivacyGuardrailsAutoConfiguration.class)
 public class PrivacyConfigurationDiagnosticsAutoConfiguration {
 

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
@@ -1,0 +1,397 @@
+package io.github.ultramancode.springai.privacy.autoconfigure;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
+import org.springframework.core.env.Environment;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+/** Warns about high-confidence typos in the library-owned, fixed property surface. */
+final class PrivacyConfigurationPropertyDiagnostics {
+
+    private static final Log logger = LogFactory.getLog(PrivacyConfigurationPropertyDiagnostics.class);
+
+    private static final ConfigurationPropertyName ROOT =
+            ConfigurationPropertyName.of("spring.ai.privacy");
+    private static final int ROOT_ELEMENTS = ROOT.getNumberOfElements();
+
+    static final List<String> ROOT_PROPERTIES = List.of(
+            "output",
+            "response-inspection",
+            "analysis",
+            "regex",
+            "tools",
+            "enabled"
+    );
+    static final List<String> OUTPUT_PROPERTIES = List.of(
+            "enabled",
+            "action",
+            "block-exception-message"
+    );
+    static final List<String> RESPONSE_INSPECTION_PROPERTIES = List.of(
+            "max-stream-frames",
+            "max-characters",
+            "max-media-bytes",
+            "stream-idle-timeout"
+    );
+    static final List<String> ANALYSIS_PROPERTIES = List.of(
+            "language",
+            "included-entity-types",
+            "minimum-score",
+            "mode",
+            "primary-provider",
+            "supplemental-providers",
+            "failure-policy",
+            "provider-minimum-scores",
+            "entity-aliases",
+            "type-conflict-fallback"
+    );
+    static final List<String> REGEX_PROPERTIES = List.of("enabled", "rules");
+    static final List<String> REGEX_RULE_PROPERTIES = List.of(
+            "entity-type",
+            "pattern",
+            "score",
+            "capture-group"
+    );
+    static final List<String> TOOLS_PROPERTIES = List.of("disclosures");
+
+    PrivacyConfigurationPropertyDiagnostics(Environment environment) {
+        findLikelyTypos(environment).forEach(PrivacyConfigurationPropertyDiagnostics::warn);
+    }
+
+    static Set<Suggestion> findLikelyTypos(Environment environment) {
+        Set<Suggestion> suggestions = new TreeSet<>();
+        for (ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
+            if (source instanceof IterableConfigurationPropertySource iterableSource) {
+                collectLikelyTypos(iterableSource, suggestions);
+            }
+        }
+        return suggestions;
+    }
+
+    /**
+     * Collects suggestions on a best-effort basis. If name enumeration fails, the
+     * source contributes no partial results and cannot block host application startup.
+     */
+    private static void collectLikelyTypos(
+            IterableConfigurationPropertySource source,
+            Set<Suggestion> suggestions
+    ) {
+        Set<Suggestion> sourceSuggestions = new TreeSet<>();
+        Iterator<ConfigurationPropertyName> names;
+        try {
+            names = source.iterator();
+        } catch (RuntimeException ignored) {
+            return;
+        }
+        while (true) {
+            ConfigurationPropertyName name;
+            try {
+                if (!names.hasNext()) {
+                    suggestions.addAll(sourceSuggestions);
+                    return;
+                }
+                name = names.next();
+            } catch (RuntimeException ignored) {
+                return;
+            }
+            if (name == null) {
+                return;
+            }
+            diagnosePropertyName(name).ifPresent(sourceSuggestions::add);
+        }
+    }
+
+    private static Optional<Suggestion> diagnosePropertyName(ConfigurationPropertyName name) {
+        if (!ROOT.isAncestorOf(name)) {
+            return Optional.empty();
+        }
+        Optional<SegmentMatch> rootMatchCandidate = closestSegmentMatch(
+                name,
+                ROOT_ELEMENTS,
+                ROOT_PROPERTIES
+        );
+        if (rootMatchCandidate.isEmpty()) {
+            return Optional.empty();
+        }
+        SegmentMatch rootMatch = rootMatchCandidate.get();
+        int propertyIndex = ROOT_ELEMENTS + rootMatch.consumedElements();
+        if (!rootMatch.exact()) {
+            // Only this typo can silently leave privacy auto-configuration inactive;
+            // other near-root names may belong to provider or host extensions.
+            if (propertyIndex == name.getNumberOfElements()
+                    && rootMatch.expected().equals("enabled")) {
+                return suggestion(ROOT.toString(), rootMatch);
+            }
+            return Optional.empty();
+        }
+        if (propertyIndex == name.getNumberOfElements()) {
+            return Optional.empty();
+        }
+        String propertyRoot = ROOT + "." + rootMatch.expected();
+        return switch (rootMatch.expected()) {
+            case "enabled" -> Optional.empty();
+            case "output" -> diagnoseFixedProperties(
+                    name,
+                    propertyIndex,
+                    propertyRoot,
+                    OUTPUT_PROPERTIES
+            );
+            case "response-inspection" -> diagnoseFixedProperties(
+                    name,
+                    propertyIndex,
+                    propertyRoot,
+                    RESPONSE_INSPECTION_PROPERTIES
+            );
+            case "analysis" -> diagnoseFixedProperties(
+                    name,
+                    propertyIndex,
+                    propertyRoot,
+                    ANALYSIS_PROPERTIES
+            );
+            case "regex" -> diagnoseRegex(name, propertyIndex, propertyRoot);
+            case "tools" -> diagnoseFixedProperties(
+                    name,
+                    propertyIndex,
+                    propertyRoot,
+                    TOOLS_PROPERTIES
+            );
+            default -> Optional.empty();
+        };
+    }
+
+    private static Optional<Suggestion> diagnoseFixedProperties(
+            ConfigurationPropertyName name,
+            int propertyIndex,
+            String propertyRoot,
+            List<String> knownProperties
+    ) {
+        Optional<SegmentMatch> match = closestSegmentMatch(name, propertyIndex, knownProperties);
+        if (match.isPresent() && !match.get().exact()) {
+            return suggestion(propertyRoot, match.get());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Suggestion> diagnoseRegex(
+            ConfigurationPropertyName name,
+            int propertyIndex,
+            String propertyRoot
+    ) {
+        Optional<SegmentMatch> propertyMatchCandidate = closestSegmentMatch(
+                name,
+                propertyIndex,
+                REGEX_PROPERTIES
+        );
+        if (propertyMatchCandidate.isEmpty()) {
+            return Optional.empty();
+        }
+        SegmentMatch propertyMatch = propertyMatchCandidate.get();
+        if (!propertyMatch.exact()) {
+            return suggestion(propertyRoot, propertyMatch);
+        }
+        int ruleIndex = propertyIndex + propertyMatch.consumedElements();
+        if (!propertyMatch.expected().equals("rules") || name.getNumberOfElements() <= ruleIndex) {
+            return Optional.empty();
+        }
+        if (!name.isNumericIndex(ruleIndex)) {
+            return Optional.empty();
+        }
+        int rulePropertyIndex = ruleIndex + 1;
+        if (name.getNumberOfElements() <= rulePropertyIndex) {
+            return Optional.empty();
+        }
+        String rulesRoot = propertyRoot + ".rules[" + element(name, ruleIndex) + "]";
+        return diagnoseFixedProperties(
+                name,
+                rulePropertyIndex,
+                rulesRoot,
+                REGEX_RULE_PROPERTIES
+        );
+    }
+
+    private static Optional<Suggestion> suggestion(
+            String propertyRoot,
+            SegmentMatch match
+    ) {
+        return Optional.of(new Suggestion(
+                propertyRoot + "." + match.actual(),
+                propertyRoot + "." + match.expected()
+        ));
+    }
+
+    private static String element(ConfigurationPropertyName name, int index) {
+        return name.getElement(index, Form.DASHED);
+    }
+
+    /**
+     * Returns the unique closest candidate within its typo threshold. Ambiguous ties
+     * intentionally produce no match.
+     */
+    private static Optional<SegmentMatch> closestSegmentMatch(
+            ConfigurationPropertyName name,
+            int propertyIndex,
+            List<String> candidates
+    ) {
+        SegmentMatch closest = null;
+        int closestDistance = Integer.MAX_VALUE;
+        boolean tied = false;
+        for (String candidate : candidates) {
+            for (SegmentVariant variant : candidateSegmentVariants(name, propertyIndex, candidate)) {
+                if (variant.actual().equals(candidate)) {
+                    return Optional.of(new SegmentMatch(
+                            variant.actual(),
+                            candidate,
+                            variant.consumedElements(),
+                            true
+                    ));
+                }
+                int distance = levenshteinDistance(variant.actual(), candidate);
+                SegmentMatch match = new SegmentMatch(
+                        variant.actual(),
+                        candidate,
+                        variant.consumedElements(),
+                        false
+                );
+                if (distance < closestDistance) {
+                    closest = match;
+                    closestDistance = distance;
+                    tied = false;
+                } else if (distance == closestDistance && !sameSuggestion(closest, match)) {
+                    tied = true;
+                }
+            }
+        }
+        if (tied || closest == null || closestDistance > typoThreshold(closest.expected())) {
+            return Optional.empty();
+        }
+        return Optional.of(closest);
+    }
+
+    /**
+     * Builds comparable forms for one dashed element and for the equivalent element
+     * sequence produced from relaxed operating-system environment variable names.
+     */
+    private static List<SegmentVariant> candidateSegmentVariants(
+            ConfigurationPropertyName name,
+            int propertyIndex,
+            String candidate
+    ) {
+        List<SegmentVariant> variants = new ArrayList<>(2);
+        String singleElement = element(name, propertyIndex);
+        variants.add(new SegmentVariant(singleElement, 1));
+
+        int candidateElements = candidate.split("-").length;
+        if (candidateElements == 1
+                || propertyIndex + candidateElements > name.getNumberOfElements()) {
+            return variants;
+        }
+        StringBuilder joinedElements = new StringBuilder();
+        for (int offset = 0; offset < candidateElements; offset++) {
+            int elementIndex = propertyIndex + offset;
+            if (name.isNumericIndex(elementIndex)) {
+                return variants;
+            }
+            if (!joinedElements.isEmpty()) {
+                joinedElements.append('-');
+            }
+            joinedElements.append(element(name, elementIndex));
+        }
+        String joined = joinedElements.toString();
+        if (!joined.equals(singleElement)) {
+            variants.add(new SegmentVariant(joined, candidateElements));
+        }
+        return variants;
+    }
+
+    private static boolean sameSuggestion(SegmentMatch left, SegmentMatch right) {
+        return left != null
+                && left.actual().equals(right.actual())
+                && left.expected().equals(right.expected());
+    }
+
+    /** Returns the heuristic maximum distance, scaled by canonical segment length. */
+    private static int typoThreshold(String expected) {
+        if (expected.length() <= 4) {
+            return 1;
+        }
+        if (expected.length() <= 8) {
+            return 3;
+        }
+        return 4;
+    }
+
+    /**
+     * Returns the Levenshtein distance used to identify likely property-name typos.
+     * Counts single-character insertions, deletions, and substitutions.
+     */
+    private static int levenshteinDistance(String left, String right) {
+        int[] previousCosts = new int[right.length() + 1];
+        int[] currentCosts = new int[right.length() + 1];
+        for (int rightIndex = 0; rightIndex <= right.length(); rightIndex++) {
+            previousCosts[rightIndex] = rightIndex;
+        }
+        for (int leftIndex = 1; leftIndex <= left.length(); leftIndex++) {
+            currentCosts[0] = leftIndex;
+            for (int rightIndex = 1; rightIndex <= right.length(); rightIndex++) {
+                int substitutionPenalty = 1;
+                if (left.charAt(leftIndex - 1) == right.charAt(rightIndex - 1)) {
+                    substitutionPenalty = 0;
+                }
+
+                int insertionCost = currentCosts[rightIndex - 1] + 1;
+                int deletionCost = previousCosts[rightIndex] + 1;
+                int substitutionCost = previousCosts[rightIndex - 1] + substitutionPenalty;
+
+                int lowestCost = Math.min(insertionCost, deletionCost);
+                currentCosts[rightIndex] = Math.min(lowestCost, substitutionCost);
+            }
+            int[] temporary = previousCosts;
+            previousCosts = currentCosts;
+            currentCosts = temporary;
+        }
+        return previousCosts[right.length()];
+    }
+
+    private static void warn(Suggestion suggestion) {
+        logger.warn("Unrecognized Spring AI Privacy Guardrails configuration property '"
+                + suggestion.actualName()
+                + "'. Did you mean '"
+                + suggestion.expectedName()
+                + "'? No configuration value was included in this diagnostic.");
+    }
+
+    record Suggestion(String actualName, String expectedName) implements Comparable<Suggestion> {
+
+        @Override
+        public int compareTo(Suggestion other) {
+            int actualComparison = this.actualName.compareTo(other.actualName);
+            return actualComparison != 0
+                    ? actualComparison
+                    : this.expectedName.compareTo(other.expectedName);
+        }
+
+    }
+
+    private record SegmentMatch(
+            String actual,
+            String expected,
+            int consumedElements,
+            boolean exact
+    ) {
+    }
+
+    private record SegmentVariant(String actual, int consumedElements) {
+    }
+
+}

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
-/** Warns about high-confidence typos in the library-owned, fixed property surface. */
+/** Warns about unrecognized names in the library-owned, fixed property surface. */
 final class PrivacyConfigurationPropertyDiagnostics {
 
     private static final Log logger = LogFactory.getLog(PrivacyConfigurationPropertyDiagnostics.class);
@@ -56,7 +56,16 @@ final class PrivacyConfigurationPropertyDiagnostics {
             "entity-aliases",
             "type-conflict-fallback"
     );
+    static final Set<String> ANALYSIS_MAP_PROPERTIES = Set.of(
+            "provider-minimum-scores",
+            "entity-aliases"
+    );
+    static final Set<String> ANALYSIS_INDEXED_SCALAR_PROPERTIES = Set.of(
+            "included-entity-types",
+            "supplemental-providers"
+    );
     static final List<String> REGEX_PROPERTIES = List.of("enabled", "rules");
+    static final Set<String> REGEX_INDEXED_OBJECT_PROPERTIES = Set.of("rules");
     static final List<String> REGEX_RULE_PROPERTIES = List.of(
             "entity-type",
             "pattern",
@@ -64,30 +73,31 @@ final class PrivacyConfigurationPropertyDiagnostics {
             "capture-group"
     );
     static final List<String> TOOLS_PROPERTIES = List.of("disclosures");
+    static final Set<String> TOOLS_MAP_PROPERTIES = Set.of("disclosures");
 
     PrivacyConfigurationPropertyDiagnostics(Environment environment) {
-        findLikelyTypos(environment).forEach(PrivacyConfigurationPropertyDiagnostics::warn);
+        findDiagnostics(environment).forEach(PrivacyConfigurationPropertyDiagnostics::warn);
     }
 
-    static Set<Suggestion> findLikelyTypos(Environment environment) {
-        Set<Suggestion> suggestions = new TreeSet<>();
+    static Set<Diagnostic> findDiagnostics(Environment environment) {
+        Set<Diagnostic> diagnostics = new TreeSet<>();
         for (ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
             if (source instanceof IterableConfigurationPropertySource iterableSource) {
-                collectLikelyTypos(iterableSource, suggestions);
+                collectDiagnostics(iterableSource, diagnostics);
             }
         }
-        return suggestions;
+        return diagnostics;
     }
 
     /**
-     * Collects suggestions on a best-effort basis. If name enumeration fails, the
+     * Collects diagnostics on a best-effort basis. If name enumeration fails, the
      * source contributes no partial results and cannot block host application startup.
      */
-    private static void collectLikelyTypos(
+    private static void collectDiagnostics(
             IterableConfigurationPropertySource source,
-            Set<Suggestion> suggestions
+            Set<Diagnostic> diagnostics
     ) {
-        Set<Suggestion> sourceSuggestions = new TreeSet<>();
+        Set<Diagnostic> sourceDiagnostics = new TreeSet<>();
         Iterator<ConfigurationPropertyName> names;
         try {
             names = source.iterator();
@@ -98,7 +108,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
             ConfigurationPropertyName name;
             try {
                 if (!names.hasNext()) {
-                    suggestions.addAll(sourceSuggestions);
+                    diagnostics.addAll(sourceDiagnostics);
                     return;
                 }
                 name = names.next();
@@ -108,11 +118,11 @@ final class PrivacyConfigurationPropertyDiagnostics {
             if (name == null) {
                 return;
             }
-            diagnosePropertyName(name).ifPresent(sourceSuggestions::add);
+            diagnosePropertyName(name).ifPresent(sourceDiagnostics::add);
         }
     }
 
-    private static Optional<Suggestion> diagnosePropertyName(ConfigurationPropertyName name) {
+    private static Optional<Diagnostic> diagnosePropertyName(ConfigurationPropertyName name) {
         if (!ROOT.isAncestorOf(name)) {
             return Optional.empty();
         }
@@ -140,7 +150,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
         }
         String propertyRoot = ROOT + "." + rootMatch.expected();
         return switch (rootMatch.expected()) {
-            case "enabled" -> Optional.empty();
+            case "enabled" -> unrecognizedFixedProperty(propertyRoot);
             case "output" -> diagnoseFixedProperties(
                     name,
                     propertyIndex,
@@ -157,33 +167,73 @@ final class PrivacyConfigurationPropertyDiagnostics {
                     name,
                     propertyIndex,
                     propertyRoot,
-                    ANALYSIS_PROPERTIES
+                    ANALYSIS_PROPERTIES,
+                    ANALYSIS_MAP_PROPERTIES,
+                    ANALYSIS_INDEXED_SCALAR_PROPERTIES
             );
             case "regex" -> diagnoseRegex(name, propertyIndex, propertyRoot);
             case "tools" -> diagnoseFixedProperties(
                     name,
                     propertyIndex,
                     propertyRoot,
-                    TOOLS_PROPERTIES
+                    TOOLS_PROPERTIES,
+                    TOOLS_MAP_PROPERTIES,
+                    Set.of()
             );
             default -> Optional.empty();
         };
     }
 
-    private static Optional<Suggestion> diagnoseFixedProperties(
+    private static Optional<Diagnostic> diagnoseFixedProperties(
             ConfigurationPropertyName name,
             int propertyIndex,
             String propertyRoot,
             List<String> knownProperties
     ) {
-        Optional<SegmentMatch> match = closestSegmentMatch(name, propertyIndex, knownProperties);
-        if (match.isPresent() && !match.get().exact()) {
-            return suggestion(propertyRoot, match.get());
-        }
-        return Optional.empty();
+        return diagnoseFixedProperties(
+                name,
+                propertyIndex,
+                propertyRoot,
+                knownProperties,
+                Set.of(),
+                Set.of()
+        );
     }
 
-    private static Optional<Suggestion> diagnoseRegex(
+    private static Optional<Diagnostic> diagnoseFixedProperties(
+            ConfigurationPropertyName name,
+            int propertyIndex,
+            String propertyRoot,
+            List<String> knownProperties,
+            Set<String> mapProperties,
+            Set<String> indexedScalarProperties
+    ) {
+        Optional<SegmentMatch> matchCandidate = closestSegmentMatch(
+                name,
+                propertyIndex,
+                knownProperties
+        );
+        if (matchCandidate.isEmpty()) {
+            return unrecognizedFixedProperty(propertyRoot);
+        }
+        SegmentMatch match = matchCandidate.get();
+        if (!match.exact()) {
+            return suggestion(propertyRoot, match);
+        }
+        int nextPropertyIndex = propertyIndex + match.consumedElements();
+        if (nextPropertyIndex == name.getNumberOfElements()
+                || mapProperties.contains(match.expected())) {
+            return Optional.empty();
+        }
+        if (indexedScalarProperties.contains(match.expected())
+                && name.isNumericIndex(nextPropertyIndex)
+                && nextPropertyIndex + 1 == name.getNumberOfElements()) {
+            return Optional.empty();
+        }
+        return unrecognizedFixedProperty(propertyRoot + "." + match.expected());
+    }
+
+    private static Optional<Diagnostic> diagnoseRegex(
             ConfigurationPropertyName name,
             int propertyIndex,
             String propertyRoot
@@ -194,18 +244,25 @@ final class PrivacyConfigurationPropertyDiagnostics {
                 REGEX_PROPERTIES
         );
         if (propertyMatchCandidate.isEmpty()) {
-            return Optional.empty();
+            return unrecognizedFixedProperty(propertyRoot);
         }
         SegmentMatch propertyMatch = propertyMatchCandidate.get();
         if (!propertyMatch.exact()) {
             return suggestion(propertyRoot, propertyMatch);
         }
         int ruleIndex = propertyIndex + propertyMatch.consumedElements();
-        if (!propertyMatch.expected().equals("rules") || name.getNumberOfElements() <= ruleIndex) {
+        if (!REGEX_INDEXED_OBJECT_PROPERTIES.contains(propertyMatch.expected())) {
+            return name.getNumberOfElements() <= ruleIndex
+                    ? Optional.empty()
+                    : unrecognizedFixedProperty(
+                            propertyRoot + "." + propertyMatch.expected()
+                    );
+        }
+        if (name.getNumberOfElements() <= ruleIndex) {
             return Optional.empty();
         }
         if (!name.isNumericIndex(ruleIndex)) {
-            return Optional.empty();
+            return unrecognizedFixedProperty(propertyRoot + ".rules");
         }
         int rulePropertyIndex = ruleIndex + 1;
         if (name.getNumberOfElements() <= rulePropertyIndex) {
@@ -220,13 +277,28 @@ final class PrivacyConfigurationPropertyDiagnostics {
         );
     }
 
-    private static Optional<Suggestion> suggestion(
+    private static Optional<Diagnostic> suggestion(
             String propertyRoot,
             SegmentMatch match
     ) {
-        return Optional.of(new Suggestion(
-                propertyRoot + "." + match.actual(),
-                propertyRoot + "." + match.expected()
+        String actualName = propertyRoot + "." + match.actual();
+        String expectedName = propertyRoot + "." + match.expected();
+        return Optional.of(new Diagnostic(
+                "Unrecognized Spring AI Privacy Guardrails configuration property '"
+                        + actualName
+                        + "'. Did you mean '"
+                        + expectedName
+                        + "'? No configuration value was included in this diagnostic."
+        ));
+    }
+
+    private static Optional<Diagnostic> unrecognizedFixedProperty(String propertyRoot) {
+        return Optional.of(new Diagnostic(
+                "Unrecognized Spring AI Privacy Guardrails configuration property detected "
+                        + "below fixed prefix '"
+                        + propertyRoot
+                        + "'. The unrecognized property name and configuration value were "
+                        + "omitted from this diagnostic."
         ));
     }
 
@@ -363,22 +435,15 @@ final class PrivacyConfigurationPropertyDiagnostics {
         return previousCosts[right.length()];
     }
 
-    private static void warn(Suggestion suggestion) {
-        logger.warn("Unrecognized Spring AI Privacy Guardrails configuration property '"
-                + suggestion.actualName()
-                + "'. Did you mean '"
-                + suggestion.expectedName()
-                + "'? No configuration value was included in this diagnostic.");
+    private static void warn(Diagnostic diagnostic) {
+        logger.warn(diagnostic.message());
     }
 
-    record Suggestion(String actualName, String expectedName) implements Comparable<Suggestion> {
+    record Diagnostic(String message) implements Comparable<Diagnostic> {
 
         @Override
-        public int compareTo(Suggestion other) {
-            int actualComparison = this.actualName.compareTo(other.actualName);
-            return actualComparison != 0
-                    ? actualComparison
-                    : this.expectedName.compareTo(other.expectedName);
+        public int compareTo(Diagnostic other) {
+            return this.message.compareTo(other.message);
         }
 
     }

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
+io.github.ultramancode.springai.privacy.autoconfigure.PrivacyConfigurationDiagnosticsAutoConfiguration
 io.github.ultramancode.springai.privacy.autoconfigure.PrivacyGuardrailsAutoConfiguration

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnosticsTest.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnosticsTest.java
@@ -1,0 +1,319 @@
+package io.github.ultramancode.springai.privacy.autoconfigure;
+
+import io.github.ultramancode.springai.privacy.core.PiiAnalyzer;
+import io.github.ultramancode.springai.privacy.core.PrivacyService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import java.beans.PropertyDescriptor;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+class PrivacyConfigurationPropertyDiagnosticsTest {
+
+    private final ApplicationContextRunner diagnosticsRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    PrivacyConfigurationDiagnosticsAutoConfiguration.class,
+                    PrivacyGuardrailsAutoConfiguration.class
+            ))
+            .withBean(PiiAnalyzer.class, () -> (text, options) -> List.of());
+
+    @Test
+    void diagnosticsAreRegisteredIndependentlyOfTheEnabledAutoConfiguration() throws Exception {
+        try (InputStream input = PrivacyConfigurationPropertyDiagnosticsTest.class.getResourceAsStream(
+                "/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+        )) {
+            assertThat(input).isNotNull();
+            assertThat(new String(input.readAllBytes(), StandardCharsets.UTF_8))
+                    .contains(PrivacyConfigurationDiagnosticsAutoConfiguration.class.getName());
+        }
+    }
+
+    @Test
+    void fixedDiagnosticSchemaStaysInSyncWithConfigurationProperties() {
+        assertDiagnosticSchemaMatches(
+                PrivacyGuardrailsProperties.class,
+                PrivacyConfigurationPropertyDiagnostics.ROOT_PROPERTIES
+        );
+        assertDiagnosticSchemaMatches(
+                PrivacyGuardrailsProperties.Output.class,
+                PrivacyConfigurationPropertyDiagnostics.OUTPUT_PROPERTIES
+        );
+        assertDiagnosticSchemaMatches(
+                PrivacyGuardrailsProperties.ResponseInspection.class,
+                PrivacyConfigurationPropertyDiagnostics.RESPONSE_INSPECTION_PROPERTIES
+        );
+        assertDiagnosticSchemaMatches(
+                PrivacyGuardrailsProperties.Analysis.class,
+                PrivacyConfigurationPropertyDiagnostics.ANALYSIS_PROPERTIES
+        );
+        assertDiagnosticSchemaMatches(
+                PrivacyGuardrailsProperties.Regex.class,
+                PrivacyConfigurationPropertyDiagnostics.REGEX_PROPERTIES
+        );
+        assertDiagnosticSchemaMatches(
+                PrivacyGuardrailsProperties.Regex.Rule.class,
+                PrivacyConfigurationPropertyDiagnostics.REGEX_RULE_PROPERTIES
+        );
+        assertDiagnosticSchemaMatches(
+                PrivacyGuardrailsProperties.Tools.class,
+                PrivacyConfigurationPropertyDiagnostics.TOOLS_PROPERTIES
+        );
+    }
+
+    @Test
+    void warnsWhenAnUnknownFixedPropertyWouldOtherwiseBeIgnored(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.enabled=true",
+                        "spring.ai.privacy.output.enabledddd=synthetic-sensitive-value"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+                    assertThat(context.getBean(PrivacyGuardrailsProperties.class)
+                            .getOutput()
+                            .isEnabled()).isFalse();
+                    assertThat(output).contains(
+                            "Unrecognized Spring AI Privacy Guardrails configuration property "
+                                    + "'spring.ai.privacy.output.enabledddd'"
+                    ).contains("Did you mean 'spring.ai.privacy.output.enabled'?")
+                            .contains("No configuration value was included in this diagnostic.")
+                            .doesNotContain("synthetic-sensitive-value");
+                });
+    }
+
+    @Test
+    void warnsAboutTheGlobalEnabledTypoEvenWhenPrivacyAutoConfigurationIsInactive(
+            CapturedOutput output
+    ) {
+        this.diagnosticsRunner
+                .withPropertyValues("spring.ai.privacy.enabledddd=synthetic-sensitive-value")
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output).contains(
+                            "'spring.ai.privacy.enabledddd'. Did you mean "
+                                    + "'spring.ai.privacy.enabled'?"
+                    ).doesNotContain("synthetic-sensitive-value");
+                });
+    }
+
+    @Test
+    void diagnosticsRemainEagerWhenTheHostEnablesGlobalLazyInitialization(
+            CapturedOutput output
+    ) {
+        this.diagnosticsRunner
+                .withInitializer(context -> context.addBeanFactoryPostProcessor(
+                        new LazyInitializationBeanFactoryPostProcessor()
+                ))
+                .withPropertyValues("spring.ai.privacy.enabledddd=synthetic-sensitive-value")
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .contains("'spring.ai.privacy.enabledddd'. Did you mean ")
+                            .contains("'spring.ai.privacy.enabled'?")
+                            .doesNotContain("synthetic-sensitive-value");
+                });
+    }
+
+    @Test
+    void recognizesDashedFixedPropertiesFromSystemEnvironmentNames(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_RESPONSE_INSPECTION_MAX_CHARACTERS", "8",
+                "SPRING_AI_PRIVACY_ANALYSIS_MINIMUM_SCORE", "0.5",
+                "SPRING_AI_PRIVACY_OUTPUT_BLOCK_EXCEPTION_MESSAGE", "safe-message",
+                "SPRING_AI_PRIVACY_REGEX_RULES_0_ENTITY_TYPE", "CUSTOMER_ID"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+            assertThat(output)
+                    .doesNotContain("Unrecognized Spring AI Privacy Guardrails configuration property")
+                    .doesNotContain("safe-message");
+        });
+    }
+
+    @Test
+    void warnsForDashedFixedPropertyTyposFromSystemEnvironmentNames(
+            CapturedOutput output
+    ) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_ENABLEDDDD", "true",
+                "SPRING_AI_PRIVACY_RESPONSE_INSPECTION_MAX_CHARACTERSS", "8",
+                "SPRING_AI_PRIVACY_OUTPUT_BLOCK_EXCEPTION_MESAGE", "synthetic-sensitive-value",
+                "SPRING_AI_PRIVACY_REGEX_RULES_0_CAPTURE_GROPU", "0"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+            assertThat(output)
+                    .contains("'spring.ai.privacy.response-inspection.max-characterss'")
+                    .contains("'spring.ai.privacy.response-inspection.max-characters'")
+                    .contains("'spring.ai.privacy.output.block-exception-mesage'")
+                    .contains("'spring.ai.privacy.output.block-exception-message'")
+                    .contains("'spring.ai.privacy.regex.rules[0].capture-gropu'")
+                    .contains("'spring.ai.privacy.regex.rules[0].capture-group'")
+                    .contains("'spring.ai.privacy.enabledddd'")
+                    .contains("'spring.ai.privacy.enabled'")
+                    .doesNotContain("synthetic-sensitive-value");
+        });
+    }
+
+    @Test
+    void ignoresProviderExtensionAndDynamicMapKeys(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.custom-provider.credentials.client-secret=synthetic-secret-one",
+                        "spring.ai.privacy.analysis.provider-minimum-scores.custom-provider=0.75",
+                        "spring.ai.privacy.analysis.entity-aliases.external-label=CUSTOMER_ID",
+                        "spring.ai.privacy.tools.disclosures.customer-lookup[0]=CUSTOMER_ID",
+                        "spring.ai.privacy.presidio.headers.Authorization=synthetic-secret-two",
+                        "spring.ai.privacy.opennlp.entity-models.CUSTOMER_RECORD=classpath:synthetic-model"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .doesNotContain("Unrecognized Spring AI Privacy Guardrails configuration property")
+                            .doesNotContain("synthetic-secret-one")
+                            .doesNotContain("synthetic-secret-two");
+                });
+    }
+
+    @Test
+    void reportsOnlyTheFixedTypoSegmentBeforePotentiallySensitiveDescendants(
+            CapturedOutput output
+    ) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.analysis.provider-minimum-scorez.synthetic-credential-name="
+                                + "synthetic-secret"
+                )
+                .run(context -> assertThat(output)
+                        .contains("'spring.ai.privacy.analysis.provider-minimum-scorez'")
+                        .contains("'spring.ai.privacy.analysis.provider-minimum-scores'")
+                        .doesNotContain("synthetic-credential-name")
+                        .doesNotContain("synthetic-secret"));
+    }
+
+    @Test
+    void ignoresDynamicSystemEnvironmentSegmentsAndTheirValues(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_ANALYSIS_PROVIDER_MINIMUM_SCORES_CUSTOM_PROVIDER", "0.75",
+                "SPRING_AI_PRIVACY_ANALYSIS_ENTITY_ALIASES_EXTERNAL_LABEL", "CUSTOMER_ID",
+                "SPRING_AI_PRIVACY_TOOLS_DISCLOSURES_CUSTOMER_LOOKUP_0", "CUSTOMER_ID",
+                "SPRING_AI_PRIVACY_PRESIDIO_HEADERS_AUTHORIZATION", "synthetic-secret-one",
+                "SPRING_AI_PRIVACY_OPENNLP_ENTITY_MODELS_CUSTOMER_RECORD", "synthetic-secret-two"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+            assertThat(output)
+                    .doesNotContain("Unrecognized Spring AI Privacy Guardrails configuration property")
+                    .doesNotContain("synthetic-secret-one")
+                    .doesNotContain("synthetic-secret-two");
+        });
+    }
+
+    @Test
+    void skipsOnlyAPropertySourceThatCannotEnumerateItsNames(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withInitializer(context -> context.getEnvironment().getPropertySources().addFirst(
+                        new ThrowingEnumerablePropertySource()
+                ))
+                .withPropertyValues("spring.ai.privacy.enabledddd=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .contains("'spring.ai.privacy.enabledddd'. Did you mean ")
+                            .contains("'spring.ai.privacy.enabled'?")
+                            .doesNotContain(ThrowingEnumerablePropertySource.SENSITIVE_MESSAGE);
+                });
+    }
+
+    private ApplicationContextRunner withSystemEnvironment(Map<String, Object> environment) {
+        return this.diagnosticsRunner.withInitializer(context ->
+                context.getEnvironment().getPropertySources().addFirst(
+                        new SystemEnvironmentPropertySource(
+                                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                                environment
+                        )
+                )
+        );
+    }
+
+    private static void assertDiagnosticSchemaMatches(
+            Class<?> propertiesType,
+            List<String> diagnosticProperties
+    ) {
+        String description = "diagnostic schema for " + propertiesType.getSimpleName();
+        assertThat(diagnosticProperties)
+                .as(description)
+                .doesNotHaveDuplicates();
+        assertThat(diagnosticProperties.stream()
+                .map(PrivacyConfigurationPropertyDiagnosticsTest::toJavaBeanPropertyName)
+                .collect(Collectors.toSet()))
+                .as(description)
+                .containsExactlyInAnyOrderElementsOf(javaBeanPropertyNames(propertiesType));
+    }
+
+    private static Set<String> javaBeanPropertyNames(Class<?> propertiesType) {
+        return Arrays.stream(BeanUtils.getPropertyDescriptors(propertiesType))
+                .map(PropertyDescriptor::getName)
+                .filter(name -> !name.equals("class"))
+                .collect(Collectors.toSet());
+    }
+
+    private static String toJavaBeanPropertyName(String dashedName) {
+        StringBuilder javaBeanName = new StringBuilder(dashedName.length());
+        boolean capitalizeNext = false;
+        for (int index = 0; index < dashedName.length(); index++) {
+            char character = dashedName.charAt(index);
+            if (character == '-') {
+                capitalizeNext = true;
+            } else if (capitalizeNext) {
+                javaBeanName.append(Character.toUpperCase(character));
+                capitalizeNext = false;
+            } else {
+                javaBeanName.append(character);
+            }
+        }
+        return javaBeanName.toString();
+    }
+
+    private static final class ThrowingEnumerablePropertySource
+            extends EnumerablePropertySource<Object> {
+
+        private static final String SENSITIVE_MESSAGE = "synthetic-sensitive-value";
+
+        private ThrowingEnumerablePropertySource() {
+            super("throwing-enumerable-property-source", new Object());
+        }
+
+        @Override
+        public String[] getPropertyNames() {
+            throw new IllegalStateException(SENSITIVE_MESSAGE);
+        }
+
+        @Override
+        public boolean containsProperty(String name) {
+            return false;
+        }
+
+        @Override
+        public Object getProperty(String name) {
+            return null;
+        }
+
+    }
+
+}

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnosticsTest.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnosticsTest.java
@@ -16,12 +16,16 @@ import org.springframework.core.env.SystemEnvironmentPropertySource;
 
 import java.beans.PropertyDescriptor;
 import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,10 +80,34 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
                 PrivacyGuardrailsProperties.Tools.class,
                 PrivacyConfigurationPropertyDiagnostics.TOOLS_PROPERTIES
         );
+        assertNoMapOrCollectionProperties(PrivacyGuardrailsProperties.class);
+        assertNoMapOrCollectionProperties(PrivacyGuardrailsProperties.Output.class);
+        assertNoMapOrCollectionProperties(
+                PrivacyGuardrailsProperties.ResponseInspection.class
+        );
+        assertContainerPropertiesMatch(
+                PrivacyGuardrailsProperties.Analysis.class,
+                PrivacyConfigurationPropertyDiagnostics.ANALYSIS_MAP_PROPERTIES,
+                PrivacyConfigurationPropertyDiagnostics.ANALYSIS_INDEXED_SCALAR_PROPERTIES,
+                Set.of()
+        );
+        assertContainerPropertiesMatch(
+                PrivacyGuardrailsProperties.Regex.class,
+                Set.of(),
+                Set.of(),
+                PrivacyConfigurationPropertyDiagnostics.REGEX_INDEXED_OBJECT_PROPERTIES
+        );
+        assertNoMapOrCollectionProperties(PrivacyGuardrailsProperties.Regex.Rule.class);
+        assertContainerPropertiesMatch(
+                PrivacyGuardrailsProperties.Tools.class,
+                PrivacyConfigurationPropertyDiagnostics.TOOLS_MAP_PROPERTIES,
+                Set.of(),
+                Set.of()
+        );
     }
 
     @Test
-    void warnsWhenAnUnknownFixedPropertyWouldOtherwiseBeIgnored(CapturedOutput output) {
+    void suggestsTheCanonicalNameForALikelyFixedPropertyTypo(CapturedOutput output) {
         this.diagnosticsRunner
                 .withPropertyValues(
                         "spring.ai.privacy.enabled=true",
@@ -96,6 +124,65 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
                     ).contains("Did you mean 'spring.ai.privacy.output.enabled'?")
                             .contains("No configuration value was included in this diagnostic.")
                             .doesNotContain("synthetic-sensitive-value");
+                });
+    }
+
+    @Test
+    void warnsWithoutEchoingDissimilarUnknownNamesInFixedConfigurationAreas(
+            CapturedOutput output
+    ) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.output.synthetic-credential-name=synthetic-secret-one",
+                        "spring.ai.privacy.response-inspection.synthetic-credential-name="
+                                + "synthetic-secret-two",
+                        "spring.ai.privacy.analysis.synthetic-credential-name=synthetic-secret-three",
+                        "spring.ai.privacy.regex.synthetic-credential-name=synthetic-secret-four",
+                        "spring.ai.privacy.tools.synthetic-credential-name=synthetic-secret-five"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .contains("below fixed prefix 'spring.ai.privacy.output'")
+                            .contains("below fixed prefix 'spring.ai.privacy.response-inspection'")
+                            .contains("below fixed prefix 'spring.ai.privacy.analysis'")
+                            .contains("below fixed prefix 'spring.ai.privacy.regex'")
+                            .contains("below fixed prefix 'spring.ai.privacy.tools'")
+                            .contains("The unrecognized property name and configuration value were "
+                                    + "omitted from this diagnostic.")
+                            .doesNotContain("synthetic-credential-name")
+                            .doesNotContain("synthetic-secret-one")
+                            .doesNotContain("synthetic-secret-two")
+                            .doesNotContain("synthetic-secret-three")
+                            .doesNotContain("synthetic-secret-four")
+                            .doesNotContain("synthetic-secret-five");
+                });
+    }
+
+    @Test
+    void warnsWithoutEchoingUnexpectedDescendantsOfFixedLeafProperties(
+            CapturedOutput output
+    ) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.output.enabled.synthetic-credential-name="
+                                + "synthetic-secret-one",
+                        "spring.ai.privacy.analysis.included-entity-types.synthetic-credential-name="
+                                + "synthetic-secret-two",
+                        "spring.ai.privacy.regex.rules[0].score.synthetic-credential-name="
+                                + "synthetic-secret-three"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .contains("below fixed prefix 'spring.ai.privacy.output.enabled'")
+                            .contains("below fixed prefix "
+                                    + "'spring.ai.privacy.analysis.included-entity-types'")
+                            .contains("below fixed prefix 'spring.ai.privacy.regex.rules[0].score'")
+                            .doesNotContain("synthetic-credential-name")
+                            .doesNotContain("synthetic-secret-one")
+                            .doesNotContain("synthetic-secret-two")
+                            .doesNotContain("synthetic-secret-three");
                 });
     }
 
@@ -137,6 +224,8 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
         withSystemEnvironment(Map.of(
                 "SPRING_AI_PRIVACY_RESPONSE_INSPECTION_MAX_CHARACTERS", "8",
                 "SPRING_AI_PRIVACY_ANALYSIS_MINIMUM_SCORE", "0.5",
+                "SPRING_AI_PRIVACY_ANALYSIS_INCLUDED_ENTITY_TYPES_0", "CUSTOMER_ID",
+                "SPRING_AI_PRIVACY_ANALYSIS_SUPPLEMENTAL_PROVIDERS_0", "custom-provider",
                 "SPRING_AI_PRIVACY_OUTPUT_BLOCK_EXCEPTION_MESSAGE", "safe-message",
                 "SPRING_AI_PRIVACY_REGEX_RULES_0_ENTITY_TYPE", "CUSTOMER_ID"
         )).run(context -> {
@@ -172,15 +261,18 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
     }
 
     @Test
-    void ignoresProviderExtensionAndDynamicMapKeys(CapturedOutput output) {
+    void ignoresProviderExtensionsAndSupportedDynamicSegments(CapturedOutput output) {
         this.diagnosticsRunner
                 .withPropertyValues(
                         "spring.ai.privacy.custom-provider.credentials.client-secret=synthetic-secret-one",
                         "spring.ai.privacy.analysis.provider-minimum-scores.custom-provider=0.75",
                         "spring.ai.privacy.analysis.entity-aliases.external-label=CUSTOMER_ID",
+                        "spring.ai.privacy.analysis.included-entity-types[0]=CUSTOMER_ID",
+                        "spring.ai.privacy.analysis.supplemental-providers[0]=custom-provider",
                         "spring.ai.privacy.tools.disclosures.customer-lookup[0]=CUSTOMER_ID",
                         "spring.ai.privacy.presidio.headers.Authorization=synthetic-secret-two",
-                        "spring.ai.privacy.opennlp.entity-models.CUSTOMER_RECORD=classpath:synthetic-model"
+                        "spring.ai.privacy.opennlp.entity-models.CUSTOMER_RECORD=classpath:synthetic-model",
+                        "spring.ai.privacy.toolz.custom-setting=true"
                 )
                 .run(context -> {
                     assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
@@ -271,6 +363,116 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
                 .map(PropertyDescriptor::getName)
                 .filter(name -> !name.equals("class"))
                 .collect(Collectors.toSet());
+    }
+
+    private static void assertNoMapOrCollectionProperties(Class<?> propertiesType) {
+        assertContainerPropertiesMatch(
+                propertiesType,
+                Set.of(),
+                Set.of(),
+                Set.of()
+        );
+    }
+
+    private static void assertContainerPropertiesMatch(
+            Class<?> propertiesType,
+            Set<String> mapProperties,
+            Set<String> indexedScalarProperties,
+            Set<String> indexedObjectProperties
+    ) {
+        assertPropertiesOfTypeMatch(propertiesType, Map.class, mapProperties);
+        Set<String> indexedProperties = Stream.concat(
+                indexedScalarProperties.stream(),
+                indexedObjectProperties.stream()
+        ).collect(Collectors.toSet());
+        assertPropertiesOfTypeMatch(propertiesType, Collection.class, indexedProperties);
+        assertCollectionElementKindMatches(
+                propertiesType,
+                true,
+                indexedScalarProperties
+        );
+        assertCollectionElementKindMatches(
+                propertiesType,
+                false,
+                indexedObjectProperties
+        );
+    }
+
+    private static void assertCollectionElementKindMatches(
+            Class<?> propertiesType,
+            boolean simpleElementType,
+            Set<String> diagnosticProperties
+    ) {
+        String elementKind = simpleElementType ? "simple" : "object";
+        String description = elementKind
+                + " indexed properties in the diagnostic schema for "
+                + propertiesType.getSimpleName();
+        Set<String> actualProperties = Arrays.stream(
+                        BeanUtils.getPropertyDescriptors(propertiesType)
+                )
+                .filter(descriptor -> Collection.class.isAssignableFrom(
+                        descriptor.getPropertyType()
+                ))
+                .filter(descriptor -> BeanUtils.isSimpleValueType(
+                        collectionElementType(descriptor)
+                ) == simpleElementType)
+                .map(PropertyDescriptor::getName)
+                .collect(Collectors.toSet());
+        assertThat(diagnosticProperties.stream()
+                .map(PrivacyConfigurationPropertyDiagnosticsTest::toJavaBeanPropertyName)
+                .collect(Collectors.toSet()))
+                .as(description)
+                .containsExactlyInAnyOrderElementsOf(actualProperties);
+    }
+
+    private static Class<?> collectionElementType(PropertyDescriptor descriptor) {
+        if (descriptor.getReadMethod() == null) {
+            throw new AssertionError("No read method for " + descriptor.getName());
+        }
+        Type returnType = descriptor.getReadMethod().getGenericReturnType();
+        if (!(returnType instanceof ParameterizedType parameterizedType)) {
+            throw new AssertionError("No generic element type for " + descriptor.getName());
+        }
+        Type[] typeArguments = parameterizedType.getActualTypeArguments();
+        if (typeArguments.length != 1) {
+            throw new AssertionError("Expected one generic element type for "
+                    + descriptor.getName());
+        }
+        Type elementType = typeArguments[0];
+        if (elementType instanceof Class<?> elementClass) {
+            return elementClass;
+        }
+        if (elementType instanceof ParameterizedType nestedType
+                && nestedType.getRawType() instanceof Class<?> rawClass) {
+            return rawClass;
+        }
+        throw new AssertionError("Unsupported generic element type for "
+                + descriptor.getName()
+                + ": "
+                + elementType.getTypeName());
+    }
+
+    private static void assertPropertiesOfTypeMatch(
+            Class<?> propertiesType,
+            Class<?> propertyType,
+            Set<String> diagnosticProperties
+    ) {
+        String description = propertyType.getSimpleName()
+                + " properties in the diagnostic schema for "
+                + propertiesType.getSimpleName();
+        Set<String> actualProperties = Arrays.stream(
+                        BeanUtils.getPropertyDescriptors(propertiesType)
+                )
+                .filter(descriptor -> propertyType.isAssignableFrom(
+                        descriptor.getPropertyType()
+                ))
+                .map(PropertyDescriptor::getName)
+                .collect(Collectors.toSet());
+        assertThat(diagnosticProperties.stream()
+                .map(PrivacyConfigurationPropertyDiagnosticsTest::toJavaBeanPropertyName)
+                .collect(Collectors.toSet()))
+                .as(description)
+                .containsExactlyInAnyOrderElementsOf(actualProperties);
     }
 
     private static String toJavaBeanPropertyName(String dashedName) {


### PR DESCRIPTION
## Summary

Add warning-only diagnostics for unrecognized names in the fixed `spring.ai.privacy` properties owned by this library. At the root level, diagnostics check only likely misspellings of `enabled`. Within the fixed `output`, `response-inspection`, `analysis`, `regex`, and `tools` areas, they warn about every unrecognized property name. The diagnostics run independently of privacy auto-configuration, so a misspelled top-level `enabled` property is still reported.

Root binding remains permissive. Provider and application extension namespaces, dynamic map keys, and supported list entries stay outside the diagnostic scope. Diagnostics never log configuration values, credentials, or dynamic map keys and never prevent host application startup. Focused regression tests and synchronized English and Korean documentation are included.

## Related Issue

Closes #4

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.