### PR TITLE
feat: add optional regex match validators

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,7 @@ ensembles deliberately.
 | `regex.rules[].pattern` | required per rule | Java regular expression evaluated against source text. |
 | `regex.rules[].score` | `0.85` | Confidence assigned to every match. |
 | `regex.rules[].capture-group` | `0` | Capturing group whose range becomes the detected span. |
+| `regex.rules[].validator-id` | unset | Stable ID of an optional `RegexPiiMatchValidator` bean. |
 | `presidio.enabled` | `false` | Enable the Presidio provider. |
 | `presidio.analyzer-url` | `http://localhost:5002` | Base analyzer URI. |
 | `presidio.timeout` | `5s` | Timeout for each complete HTTP attempt, including response-body completion, and for each health check. |
@@ -221,12 +222,46 @@ spring:
             pattern: "\\bCUST-\\d{6}\\b"
             score: 0.90
             capture-group: 0
+            validator-id: customer-id-check
 ```
 
 Each rule requires `entity-type` and `pattern`; `score` defaults to `0.85` and
-`capture-group` to `0`. Rule validation and Java pattern-compilation failures
-retain their original application-owned exception details. Do not place secrets
-in patterns, and protect startup diagnostics accordingly.
+`capture-group` to `0`. `validator-id` is opt-in and refers to the stable ID
+returned by an application-provided bean, not its Spring bean name:
+
+```java
+@Bean
+RegexPiiMatchValidator customerIdMatchValidator() {
+    return new RegexPiiMatchValidator() {
+        @Override
+        public String id() {
+            return "customer-id-check";
+        }
+
+        @Override
+        public boolean isValid(String candidate) {
+            return CustomerIds.hasValidChecksum(candidate);
+        }
+    };
+}
+```
+
+IDs use lowercase ASCII letters and digits separated by single hyphens.
+Different validator beans must not return the same ID, although multiple rules
+may reference the same validator ID. IDs are resolved once at startup. Blank,
+malformed, unknown, or duplicate validator IDs fail startup. The validator
+receives only the exact candidate selected by `capture-group`; `true` preserves
+the rule's existing span and score, while `false` excludes that candidate.
+Validator exceptions enter the configured analyzer failure-policy flow.
+Candidates may contain PII, so application validators should not include them
+in logs or exception messages or retain them in long-lived state.
+
+Validation can improve precision by rejecting format-valid false positives, but
+an incomplete validator can reduce recall by rejecting valid identifiers. Rules
+without `validator-id` keep their existing behavior. Rule validation and Java
+pattern-compilation failures retain their original application-owned exception
+details. Do not place secrets in patterns, and protect startup diagnostics
+accordingly.
 
 ## Presidio Provider
 

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -3,7 +3,7 @@
 [English](../configuration.md) | [한국어](configuration.md)
 
 <!-- i18n-source: docs/configuration.md -->
-<!-- i18n-source-sha256: e5be5c401cfc37a587d3dea678e1e6693533d9b71dd8bb5bbbdfa36fdc49158d -->
+<!-- i18n-source-sha256: 8efa150bb77f164fa2fe8a18cdbf1b3c5a270901c494498bda59a1cf34b4de1e -->
 
 이 문서는 Spring AI Privacy Guardrails를 사용하는 애플리케이션을 위한 전체
 참고 문서입니다. Base starter는 `core`와 Spring AI 경계를 제공하며, provider
@@ -68,6 +68,7 @@ Presidio와 OpenNLP를 함께 사용할 때는 base starter가 아니라 두 pro
 | `regex.rules[].pattern` | 규칙마다 필수 | 원문 텍스트에 적용할 Java 정규식입니다. |
 | `regex.rules[].score` | `0.85` | 각 일치 결과에 부여할 신뢰도입니다. |
 | `regex.rules[].capture-group` | `0` | 탐지 범위(span)로 사용할 capture group입니다. |
+| `regex.rules[].validator-id` | 설정 안 함 | 선택적인 `RegexPiiMatchValidator` bean의 안정적인 ID입니다. |
 | `presidio.enabled` | `false` | Presidio provider를 활성화합니다. |
 | `presidio.analyzer-url` | `http://localhost:5002` | 분석기의 기본 URI입니다. |
 | `presidio.timeout` | `5s` | 응답 본문 수신 완료를 포함한 각 HTTP 시도와 health check의 제한 시간입니다. |
@@ -222,12 +223,45 @@ spring:
             pattern: "\\bCUST-\\d{6}\\b"
             score: 0.90
             capture-group: 0
+            validator-id: customer-id-check
 ```
 
 각 규칙에는 `entity-type`과 `pattern`이 필요합니다. `score` 기본값은 `0.85`,
-`capture-group` 기본값은 `0`입니다. 규칙 검증과 Java pattern 컴파일 실패는
-애플리케이션 소유의 원래 예외 세부 정보를 유지합니다. Pattern에 비밀값을 넣지
-말고 시작 시 출력되는 진단 정보도 보호하세요.
+`capture-group` 기본값은 `0`입니다. `validator-id`는 opt-in이며 Spring bean
+name이 아니라 애플리케이션이 제공한 bean이 반환하는 안정적인 ID를 참조합니다.
+
+```java
+@Bean
+RegexPiiMatchValidator customerIdMatchValidator() {
+    return new RegexPiiMatchValidator() {
+        @Override
+        public String id() {
+            return "customer-id-check";
+        }
+
+        @Override
+        public boolean isValid(String candidate) {
+            return CustomerIds.hasValidChecksum(candidate);
+        }
+    };
+}
+```
+
+ID는 소문자 ASCII 문자와 숫자를 사용하고 단어를 하나의 하이픈으로 구분합니다.
+서로 다른 validator bean은 같은 ID를 반환하면 안 되지만, 여러 rule이 동일한
+validator ID를 참조할 수 있습니다. ID는 시작 시 한 번 해석됩니다. 빈 값, 잘못된
+형식, 알 수 없는 ID 또는 중복된 validator ID가 있으면 시작에 실패합니다.
+Validator에는 `capture-group`이 선택한 정확한 candidate만 전달됩니다. `true`이면
+기존 span과 score를 유지하고 `false`이면 해당 candidate를 제외합니다. Validator
+예외는 설정된 analyzer failure policy 흐름으로 전달됩니다. Candidate에는 PII가
+포함될 수 있으므로 애플리케이션 validator는 이를 로그나 예외 메시지에 포함하거나
+장기 상태에 보관하지 않아야 합니다.
+
+검증을 추가하면 형식은 맞지만 실제로 유효하지 않은 값을 거부하여 precision을
+높일 수 있지만, validator가 불완전하면 유효한 식별자도 거부하여 recall이 낮아질
+수 있습니다. `validator-id`가 없는 규칙은 기존 동작을 그대로 유지합니다. 규칙
+검증과 Java pattern 컴파일 실패는 애플리케이션 소유의 원래 예외 세부 정보를
+유지합니다. Pattern에 비밀값을 넣지 말고 시작 시 출력되는 진단 정보도 보호하세요.
 
 ## Presidio provider
 

--- a/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/RegexPiiAnalyzer.java
+++ b/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/RegexPiiAnalyzer.java
@@ -43,6 +43,10 @@ public final class RegexPiiAnalyzer implements PiiAnalyzer {
         for (CompiledRule rule : this.rules) {
             Matcher matcher = rule.pattern().matcher(text);
             while (matcher.find()) {
+                PiiSpan span = toSpan(rule, matcher);
+                if (span == null) {
+                    continue;
+                }
                 if (spans.size() >= PiiAnalyzer.MAX_RESULT_SPANS) {
                     throw new PrivacyGuardrailException(
                             PrivacyFailureCode.ANALYZER_CONTRACT_VIOLATION,
@@ -50,7 +54,7 @@ public final class RegexPiiAnalyzer implements PiiAnalyzer {
                             "Regex analyzer result exceeded the safe span limit"
                     );
                 }
-                spans.add(toSpan(rule, matcher));
+                spans.add(span);
             }
         }
         return List.copyOf(spans);
@@ -83,6 +87,22 @@ public final class RegexPiiAnalyzer implements PiiAnalyzer {
                             + " did not produce a non-empty span for entity type "
                             + rule.rule().entityType()
             );
+        }
+
+        RegexPiiMatchValidator matchValidator = rule.rule().matchValidator();
+        if (matchValidator != null) {
+            String candidate = matcher.group(captureGroup);
+            try {
+                if (!matchValidator.isValid(candidate)) {
+                    return null;
+                }
+            } catch (RuntimeException failure) {
+                throw new IllegalStateException(
+                        "Regex match validator failed for entity type "
+                                + rule.rule().entityType(),
+                        failure
+                );
+            }
         }
 
         return new PiiSpan(

--- a/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/RegexPiiMatchValidator.java
+++ b/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/RegexPiiMatchValidator.java
@@ -1,0 +1,27 @@
+package io.github.ultramancode.springai.privacy.core;
+
+/**
+ * Optional application-provided validation for a candidate selected by a
+ * {@link RegexPiiRule} capture group.
+ *
+ * <p>Implementations are shared across analyses and must therefore be thread-safe.
+ * Validator IDs are stable configuration identifiers rather than Spring bean names.
+ */
+public interface RegexPiiMatchValidator {
+
+    /**
+     * Returns the stable lowercase kebab-case ID used by configuration.
+     *
+     * @return validator ID
+     */
+    String id();
+
+    /**
+     * Returns whether one non-empty capture-group candidate should produce a PII span.
+     *
+     * @param candidate exact text selected by the rule's capture group
+     * @return {@code true} to retain the candidate, or {@code false} to exclude it
+     * @throws RuntimeException to report validator failure through the analyzer failure policy
+     */
+    boolean isValid(String candidate);
+}

--- a/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/RegexPiiRule.java
+++ b/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/RegexPiiRule.java
@@ -11,16 +11,31 @@ package io.github.ultramancode.springai.privacy.core;
  * @param score confidence assigned to every match, between {@code 0.0} and {@code 1.0}
  * @param captureGroup capture group whose range becomes the PII span; {@code 0} selects
  * the complete match
+ * @param matchValidator optional validator applied to the selected capture-group candidate;
+ * {@code null} preserves format-only matching
  */
 public record RegexPiiRule(
         String entityType,
         String pattern,
         double score,
-        int captureGroup
+        int captureGroup,
+        RegexPiiMatchValidator matchValidator
 ) {
 
     /** Default confidence score used by configuration binding when none is supplied. */
     public static final double DEFAULT_SCORE = 0.85;
+
+    /**
+     * Creates a rule without a match validator.
+     *
+     * @param entityType canonical uppercase entity type assigned to each match
+     * @param pattern Java regular expression evaluated against the complete source text
+     * @param score confidence assigned to every match
+     * @param captureGroup capture group whose range becomes the PII span
+     */
+    public RegexPiiRule(String entityType, String pattern, double score, int captureGroup) {
+        this(entityType, pattern, score, captureGroup, null);
+    }
 
     /** Validates one regex rule. */
     public RegexPiiRule {

--- a/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/RegexPiiAnalyzerTest.java
+++ b/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/RegexPiiAnalyzerTest.java
@@ -3,6 +3,8 @@ package io.github.ultramancode.springai.privacy.core;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,6 +61,115 @@ class RegexPiiAnalyzerTest {
     }
 
     @Test
+    void approvedCandidateProducesTheExistingSpanAndScore() {
+        RegexPiiAnalyzer analyzer = new RegexPiiAnalyzer(List.of(
+                new RegexPiiRule(
+                        "EMPLOYEE_ID",
+                        "\\bEMP-\\d{4}\\b",
+                        0.9,
+                        0,
+                        validator("employee-id", candidate -> true)
+                )
+        ));
+
+        assertThat(analyzer.analyze("Owner EMP-1234 approved it.", PiiAnalysisOptions.defaults()))
+                .containsExactly(new PiiSpan("EMPLOYEE_ID", 6, 14, 0.9));
+    }
+
+    @Test
+    void rejectedCandidateIsExcluded() {
+        RegexPiiAnalyzer analyzer = new RegexPiiAnalyzer(List.of(
+                new RegexPiiRule(
+                        "EMPLOYEE_ID",
+                        "\\bEMP-\\d{4}\\b",
+                        0.9,
+                        0,
+                        validator("employee-id", candidate -> candidate.endsWith("0"))
+                )
+        ));
+
+        assertThat(analyzer.analyze(
+                "EMP-1234 and EMP-5670",
+                PiiAnalysisOptions.defaults()
+        )).containsExactly(new PiiSpan("EMPLOYEE_ID", 13, 21, 0.9));
+    }
+
+    @Test
+    void validatorReceivesOnlyTheCaptureGroupCandidate() {
+        AtomicReference<String> receivedCandidate = new AtomicReference<>();
+        RegexPiiAnalyzer analyzer = new RegexPiiAnalyzer(List.of(
+                new RegexPiiRule(
+                        "TICKET_ID",
+                        "ticket[:=]\\s*(TKT-\\d{3})",
+                        0.8,
+                        1,
+                        validator("ticket-id", candidate -> {
+                            receivedCandidate.set(candidate);
+                            return true;
+                        })
+                )
+        ));
+
+        assertThat(analyzer.analyze(
+                "internal ticket: TKT-123 is linked",
+                PiiAnalysisOptions.defaults()
+        )).containsExactly(new PiiSpan("TICKET_ID", 17, 24, 0.8));
+        assertThat(receivedCandidate).hasValue("TKT-123");
+    }
+
+    @Test
+    void validatorFailureUsesTheExistingAnalyzerFailurePolicyWithoutLeakingTheCandidate() {
+        String candidate = "EMP-1234";
+        RegexPiiAnalyzer analyzer = new RegexPiiAnalyzer(List.of(
+                new RegexPiiRule(
+                        "EMPLOYEE_ID",
+                        "\\bEMP-\\d{4}\\b",
+                        0.9,
+                        0,
+                        validator("employee-id", value -> {
+                            throw new IllegalStateException("invalid " + value);
+                        })
+                )
+        ));
+
+        assertThatThrownBy(() -> analyzer.analyze(candidate, PiiAnalysisOptions.defaults()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Regex match validator failed for entity type EMPLOYEE_ID")
+                .hasMessageNotContaining(candidate);
+
+        AtomicReference<PiiAnalyzerFailure> observedFailure = new AtomicReference<>();
+        PrivacyService service = new PrivacyService(
+                List.of(analyzer, new PiiAnalyzer() {
+                    @Override
+                    public List<PiiSpan> analyze(String text, PiiAnalysisOptions options) {
+                        return List.of();
+                    }
+
+                    @Override
+                    public String providerId() {
+                        return "WORKING";
+                    }
+                }),
+                PiiAnalysisOptions.defaults(),
+                EntityTypeRegistry.defaults(),
+                PiiResolutionPolicy.builder()
+                        .failurePolicy(PiiAnalyzerFailurePolicy.ALLOW_PARTIAL)
+                        .build(),
+                observedFailure::set
+        );
+
+        assertThat(service.analyze(candidate)).isEmpty();
+        assertThat(observedFailure.get())
+                .isEqualTo(new PiiAnalyzerFailure(
+                        RegexPiiAnalyzer.PROVIDER_ID,
+                        PrivacyFailureCode.ANALYZER_EXECUTION_FAILED,
+                        PrivacyPhase.ANALYSIS,
+                        1
+                ));
+        assertThat(observedFailure.get().toString()).doesNotContain(candidate);
+    }
+
+    @Test
     void constructorRejectsMissingCaptureGroup() {
         assertThatThrownBy(() -> new RegexPiiAnalyzer(List.of(
                 new RegexPiiRule("TICKET_ID", "TKT-\\d{3}", 0.8, 1)
@@ -78,5 +189,22 @@ class RegexPiiAnalyzerTest {
                 .hasMessageContaining("capture group 1")
                 .hasMessageContaining("TICKET_ID")
                 .hasMessageNotContaining("public");
+    }
+
+    private RegexPiiMatchValidator validator(
+            String id,
+            Predicate<String> validation
+    ) {
+        return new RegexPiiMatchValidator() {
+            @Override
+            public String id() {
+                return id;
+            }
+
+            @Override
+            public boolean isValid(String candidate) {
+                return validation.test(candidate);
+            }
+        };
     }
 }

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
@@ -70,7 +70,8 @@ final class PrivacyConfigurationPropertyDiagnostics {
             "entity-type",
             "pattern",
             "score",
-            "capture-group"
+            "capture-group",
+            "validator-id"
     );
     static final List<String> TOOLS_PROPERTIES = List.of("disclosures");
     static final Set<String> TOOLS_MAP_PROPERTIES = Set.of("disclosures");

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfiguration.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfiguration.java
@@ -7,6 +7,7 @@ import io.github.ultramancode.springai.privacy.core.PiiAnalyzer;
 import io.github.ultramancode.springai.privacy.core.PiiResolutionPolicy;
 import io.github.ultramancode.springai.privacy.core.PrivacyService;
 import io.github.ultramancode.springai.privacy.core.RegexPiiAnalyzer;
+import io.github.ultramancode.springai.privacy.core.RegexPiiMatchValidator;
 import io.github.ultramancode.springai.privacy.core.RegexPiiRule;
 import io.github.ultramancode.springai.privacy.springai.PrivacyInputAdvisor;
 import io.github.ultramancode.springai.privacy.springai.PrivacyLifecycleAdvisor;
@@ -26,13 +27,21 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 /** Auto-configures core privacy services and the fixed Spring AI privacy boundary. */
 @AutoConfiguration
 @ConditionalOnProperty(prefix = "spring.ai.privacy", name = "enabled", havingValue = "true")
 @EnableConfigurationProperties(PrivacyGuardrailsProperties.class)
 public class PrivacyGuardrailsAutoConfiguration {
+
+    private static final Pattern REGEX_MATCH_VALIDATOR_ID_SYNTAX = Pattern.compile(
+            "[a-z0-9]+(?:-[a-z0-9]+)*"
+    );
 
     @Bean
     @ConditionalOnMissingBean
@@ -62,18 +71,79 @@ public class PrivacyGuardrailsAutoConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "spring.ai.privacy.regex", name = "enabled", havingValue = "true")
     @ConditionalOnMissingBean(RegexPiiAnalyzer.class)
-    RegexPiiAnalyzer regexPiiAnalyzer(PrivacyGuardrailsProperties properties) {
+    RegexPiiAnalyzer regexPiiAnalyzer(
+            PrivacyGuardrailsProperties properties,
+            List<RegexPiiMatchValidator> matchValidators
+    ) {
         List<PrivacyGuardrailsProperties.Regex.Rule> configuredRules = requireConfiguredRegexRules(properties);
+        Map<String, RegexPiiMatchValidator> matchValidatorsById = indexMatchValidators(matchValidators);
         List<RegexPiiRule> rules = new ArrayList<>(configuredRules.size());
-        for (PrivacyGuardrailsProperties.Regex.Rule rule : configuredRules) {
+        for (int index = 0; index < configuredRules.size(); index++) {
+            PrivacyGuardrailsProperties.Regex.Rule rule = configuredRules.get(index);
             rules.add(new RegexPiiRule(
                     rule.getEntityType(),
                     rule.getPattern(),
                     rule.getScore(),
-                    rule.getCaptureGroup()
+                    rule.getCaptureGroup(),
+                    resolveMatchValidator(rule.getValidatorId(), index, matchValidatorsById)
             ));
         }
         return new RegexPiiAnalyzer(rules);
+    }
+
+    private Map<String, RegexPiiMatchValidator> indexMatchValidators(
+            List<RegexPiiMatchValidator> matchValidators
+    ) {
+        Map<String, RegexPiiMatchValidator> validatorsById = new LinkedHashMap<>();
+        for (RegexPiiMatchValidator matchValidator : matchValidators) {
+            RegexPiiMatchValidator validator = Objects.requireNonNull(
+                    matchValidator,
+                    "RegexPiiMatchValidator beans must not be null"
+            );
+            String validatorId = requireValidValidatorId(
+                    validator.id(),
+                    "RegexPiiMatchValidator.id"
+            );
+            if (validatorsById.putIfAbsent(validatorId, validator) != null) {
+                throw new IllegalStateException(
+                        "Multiple RegexPiiMatchValidator beans use validator ID '"
+                                + validatorId + "'"
+                );
+            }
+        }
+        return validatorsById;
+    }
+
+    private RegexPiiMatchValidator resolveMatchValidator(
+            String configuredValidatorId,
+            int ruleIndex,
+            Map<String, RegexPiiMatchValidator> matchValidatorsById
+    ) {
+        if (configuredValidatorId == null) {
+            return null;
+        }
+        String property = "spring.ai.privacy.regex.rules[" + ruleIndex + "].validator-id";
+        String validatorId = requireValidValidatorId(configuredValidatorId, property);
+        RegexPiiMatchValidator matchValidator = matchValidatorsById.get(validatorId);
+        if (matchValidator == null) {
+            throw new IllegalStateException(
+                    property + " references unknown validator ID '" + validatorId + "'"
+            );
+        }
+        return matchValidator;
+    }
+
+    private String requireValidValidatorId(String validatorId, String description) {
+        if (validatorId == null || validatorId.isBlank()) {
+            throw new IllegalStateException(description + " must not be blank");
+        }
+        if (!REGEX_MATCH_VALIDATOR_ID_SYNTAX.matcher(validatorId).matches()) {
+            throw new IllegalStateException(
+                    description + " must use lowercase ASCII letters and digits "
+                            + "separated by single hyphens"
+            );
+        }
+        return validatorId;
     }
 
     private List<PrivacyGuardrailsProperties.Regex.Rule> requireConfiguredRegexRules(

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsProperties.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsProperties.java
@@ -315,7 +315,7 @@ public class PrivacyGuardrailsProperties {
 
         /** Whether the built-in regular-expression analyzer is enabled. */
         private boolean enabled = false;
-        /** Ordered detection rules; each item requires entity type and pattern, with optional score and capture group. */
+        /** Ordered rules requiring entity type and pattern, with optional score, capture group, and validator ID. */
         private List<Rule> rules = new ArrayList<>();
 
         public boolean isEnabled() {
@@ -345,6 +345,8 @@ public class PrivacyGuardrailsProperties {
             private double score = RegexPiiRule.DEFAULT_SCORE;
             /** Capturing group that identifies the entity text. */
             private int captureGroup = 0;
+            /** Optional stable ID of a RegexPiiMatchValidator bean. */
+            private String validatorId;
 
             public String getEntityType() {
                 return this.entityType;
@@ -376,6 +378,14 @@ public class PrivacyGuardrailsProperties {
 
             public void setCaptureGroup(int captureGroup) {
                 this.captureGroup = captureGroup;
+            }
+
+            public String getValidatorId() {
+                return this.validatorId;
+            }
+
+            public void setValidatorId(String validatorId) {
+                this.validatorId = validatorId;
             }
         }
     }

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfigurationTest.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfigurationTest.java
@@ -13,6 +13,7 @@ import io.github.ultramancode.springai.privacy.core.PiiSpan;
 import io.github.ultramancode.springai.privacy.core.PrivacyService;
 import io.github.ultramancode.springai.privacy.core.PrivacyGuardrailException;
 import io.github.ultramancode.springai.privacy.core.RegexPiiAnalyzer;
+import io.github.ultramancode.springai.privacy.core.RegexPiiMatchValidator;
 import io.github.ultramancode.springai.privacy.core.RegexPiiRule;
 import io.github.ultramancode.springai.privacy.core.ResolvedPiiSpan;
 import io.github.ultramancode.springai.privacy.springai.PrivacyInputAdvisor;
@@ -53,6 +54,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.PatternSyntaxException;
 
@@ -88,7 +90,13 @@ class PrivacyGuardrailsAutoConfigurationTest {
                     .contains("spring.ai.privacy.response-inspection.max-stream-frames")
                     .contains("spring.ai.privacy.response-inspection.max-characters")
                     .contains("spring.ai.privacy.response-inspection.max-media-bytes")
-                    .contains("spring.ai.privacy.response-inspection.stream-idle-timeout");
+                    .contains("spring.ai.privacy.response-inspection.stream-idle-timeout")
+                    .contains("\"name\": \"spring.ai.privacy.regex.rules\"")
+                    .contains("\"type\": \"java.util.List<io.github.ultramancode.springai.privacy.autoconfigure."
+                            + "PrivacyGuardrailsProperties$Regex$Rule>\"")
+                    .contains("Ordered rules requiring entity type and pattern, with optional score, "
+                            + "capture group, and validator ID.")
+                    .doesNotContain("spring.ai.privacy.regex.rules[].validator-id");
         }
     }
 
@@ -185,7 +193,7 @@ class PrivacyGuardrailsAutoConfigurationTest {
         properties.getRegex().getRules().add(null);
         PrivacyGuardrailsAutoConfiguration autoConfiguration = new PrivacyGuardrailsAutoConfiguration();
 
-        assertThatThrownBy(() -> autoConfiguration.regexPiiAnalyzer(properties))
+        assertThatThrownBy(() -> autoConfiguration.regexPiiAnalyzer(properties, List.of()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("spring.ai.privacy.regex.rules[0] must not be null");
     }
@@ -335,7 +343,8 @@ class PrivacyGuardrailsAutoConfigurationTest {
         rule.setPattern("(?<secret>CUST-[");
         properties.getRegex().setRules(List.of(rule));
 
-        assertThatThrownBy(() -> new PrivacyGuardrailsAutoConfiguration().regexPiiAnalyzer(properties))
+        assertThatThrownBy(() -> new PrivacyGuardrailsAutoConfiguration()
+                .regexPiiAnalyzer(properties, List.of()))
                 .isInstanceOf(PatternSyntaxException.class)
                 .hasMessageContaining("CUST");
     }
@@ -578,6 +587,106 @@ class PrivacyGuardrailsAutoConfigurationTest {
     }
 
     @Test
+    void autoConfigurationResolvesValidatorIdOnceAndBindsItToTheRuntimeRule() {
+        AtomicInteger idCalls = new AtomicInteger();
+        AtomicReference<String> receivedCandidate = new AtomicReference<>();
+        RegexPiiMatchValidator validator = new RegexPiiMatchValidator() {
+            @Override
+            public String id() {
+                idCalls.incrementAndGet();
+                return "employee-id-check";
+            }
+
+            @Override
+            public boolean isValid(String candidate) {
+                receivedCandidate.set(candidate);
+                return candidate.endsWith("0");
+            }
+        };
+
+        this.contextRunner
+                .withBean("unrelatedSpringBeanName", RegexPiiMatchValidator.class, () -> validator)
+                .withPropertyValues(
+                        "spring.ai.privacy.regex.enabled=true",
+                        "spring.ai.privacy.regex.rules[0].entity-type=EMPLOYEE_ID",
+                        "spring.ai.privacy.regex.rules[0].pattern=\\bEMP-\\d{4}\\b",
+                        "spring.ai.privacy.regex.rules[0].score=0.91",
+                        "spring.ai.privacy.regex.rules[0].validator-id=employee-id-check"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    RegexPiiAnalyzer analyzer = context.getBean(RegexPiiAnalyzer.class);
+                    assertThat(idCalls).hasValue(1);
+
+                    assertThat(analyzer.analyze(
+                            "EMP-1234 and EMP-5670",
+                            context.getBean(PiiAnalysisOptions.class)
+                    )).containsExactly(new PiiSpan("EMPLOYEE_ID", 13, 21, 0.91));
+                    assertThat(receivedCandidate).hasValue("EMP-5670");
+                    assertThat(idCalls).hasValue(1);
+                });
+    }
+
+    @Test
+    void autoConfigurationRejectsUnknownValidatorIdAtStartup() {
+        regexContext("missing-check").run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasRootCauseMessage(
+                    "spring.ai.privacy.regex.rules[0].validator-id references unknown validator ID "
+                            + "'missing-check'"
+            );
+        });
+    }
+
+    @Test
+    void autoConfigurationRejectsBlankValidatorIdAtStartup() {
+        regexContext("").run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasRootCauseMessage(
+                    "spring.ai.privacy.regex.rules[0].validator-id must not be blank"
+            );
+        });
+    }
+
+    @Test
+    void autoConfigurationRejectsMalformedValidatorIdAtStartup() {
+        regexContext("Employee ID").run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasRootCauseMessage(
+                    "spring.ai.privacy.regex.rules[0].validator-id must use lowercase ASCII letters "
+                            + "and digits separated by single hyphens"
+            );
+        });
+    }
+
+    @Test
+    void autoConfigurationRejectsDuplicateValidatorIdsAtStartup() {
+        this.contextRunner
+                .withBean(
+                        "firstValidatorBean",
+                        RegexPiiMatchValidator.class,
+                        () -> matchValidator("employee-id-check", candidate -> true)
+                )
+                .withBean(
+                        "secondValidatorBean",
+                        RegexPiiMatchValidator.class,
+                        () -> matchValidator("employee-id-check", candidate -> false)
+                )
+                .withPropertyValues(
+                        "spring.ai.privacy.regex.enabled=true",
+                        "spring.ai.privacy.regex.rules[0].entity-type=EMPLOYEE_ID",
+                        "spring.ai.privacy.regex.rules[0].pattern=\\bEMP-\\d{4}\\b"
+                )
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).hasRootCauseMessage(
+                            "Multiple RegexPiiMatchValidator beans use validator ID "
+                                    + "'employee-id-check'"
+                    );
+                });
+    }
+
+    @Test
     void autoConfigurationWiresSanitizedPartialFailureObserverIntoRuntimeAnalysis() {
         AtomicReference<PiiAnalyzerFailure> observed = new AtomicReference<>();
         this.contextRunner
@@ -661,6 +770,32 @@ class PrivacyGuardrailsAutoConfigurationTest {
 
     private ToolDefinition tool(String name) {
         return ToolDefinition.builder().name(name).description(name).inputSchema("{}").build();
+    }
+
+    private ApplicationContextRunner regexContext(String validatorId) {
+        return this.contextRunner.withPropertyValues(
+                "spring.ai.privacy.regex.enabled=true",
+                "spring.ai.privacy.regex.rules[0].entity-type=EMPLOYEE_ID",
+                "spring.ai.privacy.regex.rules[0].pattern=\\bEMP-\\d{4}\\b",
+                "spring.ai.privacy.regex.rules[0].validator-id=" + validatorId
+        );
+    }
+
+    private static RegexPiiMatchValidator matchValidator(
+            String id,
+            Predicate<String> validation
+    ) {
+        return new RegexPiiMatchValidator() {
+            @Override
+            public String id() {
+                return id;
+            }
+
+            @Override
+            public boolean isValid(String candidate) {
+                return validation.test(candidate);
+            }
+        };
     }
 
     private static PiiAnalyzer emailAnalyzer() {


### PR DESCRIPTION
## Summary

Add opt-in validation for regex matches through application-provided `RegexPiiMatchValidator` beans. 
Regex rules reference validators by stable `validator-id` values. 

Auto-configuration validates and resolves those IDs once at startup and binds validators directly to runtime rules.
Blank, malformed, unknown, and duplicate bean-provided IDs fail startup.

Validators receive only the candidate selected by `capture-group`.
Approved candidates preserve the existing span and score, while rejected candidates are excluded.
Validator exceptions enter the existing analyzer failure flow without exposing candidate values in library-generated diagnostics.

Rules without validators retain their existing behavior. 

## Related Issue

Closes #7

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`)
  per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks
  locally.
- [x] I updated any affected documentation and configuration examples.