### PR TITLE
fix: align configuration diagnostics with relaxed binding

### DIFF
--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyCandidateCollector.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyCandidateCollector.java
@@ -1,0 +1,240 @@
+package io.github.ultramancode.springai.privacy.autoconfigure;
+
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
+import org.springframework.boot.env.PropertySourceInfo;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** Collects configuration-property names and the source context needed to diagnose them. */
+final class PrivacyConfigurationPropertyCandidateCollector {
+
+    private PrivacyConfigurationPropertyCandidateCollector() {
+    }
+
+    static List<PropertyNameCandidate> collect(Environment environment) {
+        List<PropertyNameCandidate> candidates = new ArrayList<>();
+        collectFromEnvironment(environment, candidates);
+        return List.copyOf(candidates);
+    }
+
+    /**
+     * Walks raw property sources on a best-effort basis. If iteration fails, candidates
+     * already collected from preceding sources are retained.
+     */
+    private static void collectFromEnvironment(
+            Environment environment,
+            List<PropertyNameCandidate> candidates
+    ) {
+        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
+            return;
+        }
+        Iterator<PropertySource<?>> sources;
+        try {
+            sources = configurableEnvironment.getPropertySources().iterator();
+        } catch (RuntimeException ignored) {
+            return;
+        }
+        while (true) {
+            PropertySource<?> source;
+            try {
+                if (!sources.hasNext()) {
+                    return;
+                }
+                source = sources.next();
+            } catch (RuntimeException ignored) {
+                return;
+            }
+            adaptPropertySourceAndCollectCandidates(source, candidates);
+        }
+    }
+
+    /**
+     * Adapts one raw property source independently. An adapter failure skips only that
+     * source, while non-iterable adapters are intentionally ignored.
+     */
+    private static void adaptPropertySourceAndCollectCandidates(
+            PropertySource<?> propertySource,
+            List<PropertyNameCandidate> candidates
+    ) {
+        Iterator<ConfigurationPropertySource> sources;
+        try {
+            sources = ConfigurationPropertySources.from(List.of(propertySource)).iterator();
+        } catch (RuntimeException ignored) {
+            return;
+        }
+        while (true) {
+            ConfigurationPropertySource source;
+            try {
+                if (!sources.hasNext()) {
+                    return;
+                }
+                source = sources.next();
+            } catch (RuntimeException ignored) {
+                return;
+            }
+            if (source instanceof IterableConfigurationPropertySource iterableSource) {
+                collectCandidatesUsingSourceMapping(iterableSource)
+                        .ifPresent(candidates::addAll);
+            }
+        }
+    }
+
+    /**
+     * Uses the mapping semantics of one adapted source without exposing partial results.
+     * An empty optional means inspection failed; a present empty list means it succeeded
+     * with no candidates.
+     */
+    private static Optional<List<PropertyNameCandidate>> collectCandidatesUsingSourceMapping(
+            IterableConfigurationPropertySource source
+    ) {
+        try {
+            Object underlyingSource = source.getUnderlyingSource();
+            if (!(underlyingSource instanceof SystemEnvironmentPropertySource propertySource)) {
+                return collectDirectlyEnumeratedCandidates(source);
+            }
+            String name = propertySource.getName();
+            String systemEnvironment =
+                    StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
+            if (!name.equals(systemEnvironment)
+                    && !name.endsWith("-" + systemEnvironment)) {
+                return collectDirectlyEnumeratedCandidates(source);
+            }
+            return collectCandidatesFromSystemEnvironment(propertySource);
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /** Pairs directly enumerated names with their already-adapted source. */
+    private static Optional<List<PropertyNameCandidate>> collectDirectlyEnumeratedCandidates(
+            IterableConfigurationPropertySource source
+    ) {
+        Optional<List<ConfigurationPropertyName>> names = enumeratePropertyNames(source);
+        if (names.isEmpty()) {
+            return Optional.empty();
+        }
+        DiagnosticContext context = new DiagnosticContext(source, false);
+        List<PropertyNameCandidate> candidates = new ArrayList<>(names.get().size());
+        for (ConfigurationPropertyName name : names.get()) {
+            candidates.add(new PropertyNameCandidate(name, context));
+        }
+        return Optional.of(List.copyOf(candidates));
+    }
+
+    /** Discards every partially enumerated name if the source iterator fails. */
+    private static Optional<List<ConfigurationPropertyName>> enumeratePropertyNames(
+            IterableConfigurationPropertySource source
+    ) {
+        List<ConfigurationPropertyName> names = new ArrayList<>();
+        try {
+            for (ConfigurationPropertyName name : source) {
+                if (name == null) {
+                    return Optional.empty();
+                }
+                names.add(name);
+            }
+            return Optional.of(List.copyOf(names));
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Maps every raw variable independently. This mirrors Boot's lookup without reading
+     * values and prevents one valid alias from hiding another invalid name.
+     */
+    private static Optional<List<PropertyNameCandidate>> collectCandidatesFromSystemEnvironment(
+            SystemEnvironmentPropertySource propertySource
+    ) {
+        try {
+            if (propertySource instanceof PropertySourceInfo sourceInfo) {
+                String prefix = sourceInfo.getPrefix();
+                if (prefix != null && !prefix.isBlank()) {
+                    // Prefix-aware environment mapping has additional whole-name
+                    // semantics, so skipping it avoids speculative false warnings.
+                    return Optional.of(List.of());
+                }
+            }
+            List<PropertyNameCandidate> candidates = new ArrayList<>();
+            for (String propertyName : propertySource.getPropertyNames()) {
+                if (propertyName == null) {
+                    return Optional.empty();
+                }
+                Optional<List<PropertyNameCandidate>> mappedCandidates =
+                        mapEnvironmentVariableToCandidates(
+                                propertySource.getName(),
+                                propertyName
+                        );
+                if (mappedCandidates.isEmpty()) {
+                    return Optional.empty();
+                }
+                candidates.addAll(mappedCandidates.get());
+            }
+            return Optional.of(List.copyOf(candidates));
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Maps one environment variable through Boot using a one-entry source, keeping its
+     * aliases independent from every other variable in the original source.
+     */
+    private static Optional<List<PropertyNameCandidate>> mapEnvironmentVariableToCandidates(
+            String propertySourceName,
+            String environmentVariableName
+    ) {
+        try {
+            PropertySource<?> isolatedSource = new SystemEnvironmentPropertySource(
+                    propertySourceName,
+                    Map.of(environmentVariableName, Boolean.TRUE)
+            );
+            List<PropertyNameCandidate> candidates = new ArrayList<>();
+            for (ConfigurationPropertySource source :
+                    ConfigurationPropertySources.from(List.of(isolatedSource))) {
+                if (!(source instanceof IterableConfigurationPropertySource iterableSource)) {
+                    continue;
+                }
+                Optional<List<ConfigurationPropertyName>> mappedNames =
+                        enumeratePropertyNames(iterableSource);
+                if (mappedNames.isEmpty()) {
+                    return Optional.empty();
+                }
+                DiagnosticContext context = new DiagnosticContext(iterableSource, true);
+                for (ConfigurationPropertyName mappedName : mappedNames.get()) {
+                    candidates.add(new PropertyNameCandidate(mappedName, context));
+                }
+            }
+            return Optional.of(List.copyOf(candidates));
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /** Source and mapping mode required while diagnosing one candidate name. */
+    record DiagnosticContext(
+            IterableConfigurationPropertySource source,
+            boolean systemEnvironmentMapping
+    ) {
+    }
+
+    /** A discovered property name paired with the context required to diagnose it. */
+    record PropertyNameCandidate(
+            ConfigurationPropertyName name,
+            DiagnosticContext context
+    ) {
+    }
+
+}

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
@@ -1,23 +1,15 @@
 package io.github.ultramancode.springai.privacy.autoconfigure;
 
+import io.github.ultramancode.springai.privacy.autoconfigure.PrivacyConfigurationPropertyCandidateCollector.DiagnosticContext;
+import io.github.ultramancode.springai.privacy.autoconfigure.PrivacyConfigurationPropertyCandidateCollector.PropertyNameCandidate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
-import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
-import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
-import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
-import org.springframework.boot.env.PropertySourceInfo;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
-import org.springframework.core.env.PropertySource;
-import org.springframework.core.env.StandardEnvironment;
-import org.springframework.core.env.SystemEnvironmentPropertySource;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -88,226 +80,17 @@ final class PrivacyConfigurationPropertyDiagnostics {
 
     static Set<Diagnostic> findDiagnostics(Environment environment) {
         Set<Diagnostic> diagnostics = new TreeSet<>();
-        collectDiagnostics(environment, diagnostics);
+        for (PropertyNameCandidate candidate :
+                PrivacyConfigurationPropertyCandidateCollector.collect(environment)) {
+            diagnosePropertyName(candidate.name(), candidate.context())
+                    .ifPresent(diagnostics::add);
+        }
         return diagnostics;
-    }
-
-    /**
-     * Collects diagnostics on a best-effort basis. If property-source iteration or
-     * adaptation fails, already collected diagnostics are retained and startup continues.
-     */
-    private static void collectDiagnostics(
-            Environment environment,
-            Set<Diagnostic> diagnostics
-    ) {
-        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
-            return;
-        }
-        Iterator<PropertySource<?>> sources;
-        try {
-            sources = configurableEnvironment.getPropertySources().iterator();
-        } catch (RuntimeException ignored) {
-            return;
-        }
-        while (true) {
-            PropertySource<?> source;
-            try {
-                if (!sources.hasNext()) {
-                    return;
-                }
-                source = sources.next();
-            } catch (RuntimeException ignored) {
-                return;
-            }
-            collectDiagnostics(source, diagnostics);
-        }
-    }
-
-    /** Adapts each raw property source independently so one bad adapter is isolated. */
-    private static void collectDiagnostics(
-            PropertySource<?> propertySource,
-            Set<Diagnostic> diagnostics
-    ) {
-        Iterator<ConfigurationPropertySource> sources;
-        try {
-            sources = ConfigurationPropertySources.from(List.of(propertySource)).iterator();
-        } catch (RuntimeException ignored) {
-            return;
-        }
-        while (true) {
-            ConfigurationPropertySource source;
-            try {
-                if (!sources.hasNext()) {
-                    return;
-                }
-                source = sources.next();
-            } catch (RuntimeException ignored) {
-                return;
-            }
-            if (source instanceof IterableConfigurationPropertySource iterableSource) {
-                collectDiagnostics(iterableSource, diagnostics);
-            }
-        }
-    }
-
-    /**
-     * Collects diagnostics on a best-effort basis. If name enumeration fails, the
-     * source contributes no partial results and cannot block host application startup.
-     */
-    private static void collectDiagnostics(
-            IterableConfigurationPropertySource source,
-            Set<Diagnostic> diagnostics
-    ) {
-        Optional<List<DiagnosticName>> diagnosticNames = diagnosticNames(source);
-        if (diagnosticNames.isEmpty()) {
-            return;
-        }
-        Set<Diagnostic> sourceDiagnostics = new TreeSet<>();
-        for (DiagnosticName diagnosticName : diagnosticNames.get()) {
-            diagnosePropertyName(diagnosticName.name(), diagnosticName.source())
-                    .ifPresent(sourceDiagnostics::add);
-        }
-        diagnostics.addAll(sourceDiagnostics);
-    }
-
-    private static Optional<List<DiagnosticName>> diagnosticNames(
-            IterableConfigurationPropertySource source
-    ) {
-        try {
-            Object underlyingSource = source.getUnderlyingSource();
-            if (!(underlyingSource instanceof SystemEnvironmentPropertySource propertySource)) {
-                return nonSystemEnvironmentDiagnosticNames(source);
-            }
-            String name = propertySource.getName();
-            String systemEnvironment =
-                    StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
-            if (!name.equals(systemEnvironment)
-                    && !name.endsWith("-" + systemEnvironment)) {
-                return nonSystemEnvironmentDiagnosticNames(source);
-            }
-            return systemEnvironmentDiagnosticNames(propertySource);
-        } catch (RuntimeException ignored) {
-            return Optional.empty();
-        }
-    }
-
-    private static Optional<List<DiagnosticName>> nonSystemEnvironmentDiagnosticNames(
-            IterableConfigurationPropertySource source
-    ) {
-        Optional<List<ConfigurationPropertyName>> names = configurationPropertyNames(source);
-        if (names.isEmpty()) {
-            return Optional.empty();
-        }
-        List<DiagnosticName> diagnosticNames = new ArrayList<>(names.get().size());
-        for (ConfigurationPropertyName name : names.get()) {
-            diagnosticNames.add(new DiagnosticName(
-                    name,
-                    new DiagnosticSource(source, false)
-            ));
-        }
-        return Optional.of(List.copyOf(diagnosticNames));
-    }
-
-    private static Optional<List<ConfigurationPropertyName>> configurationPropertyNames(
-            IterableConfigurationPropertySource source
-    ) {
-        List<ConfigurationPropertyName> names = new ArrayList<>();
-        Iterator<ConfigurationPropertyName> iterator;
-        try {
-            iterator = source.iterator();
-        } catch (RuntimeException ignored) {
-            return Optional.empty();
-        }
-        while (true) {
-            try {
-                if (!iterator.hasNext()) {
-                    return Optional.of(List.copyOf(names));
-                }
-                ConfigurationPropertyName name = iterator.next();
-                if (name == null) {
-                    return Optional.empty();
-                }
-                names.add(name);
-            } catch (RuntimeException ignored) {
-                return Optional.empty();
-            }
-        }
-    }
-
-    /**
-     * Gives each raw variable a one-entry resolver. This mirrors Boot's lookup without
-     * reading the real value and prevents one valid alias from hiding another bad name.
-     */
-    private static Optional<List<DiagnosticName>> systemEnvironmentDiagnosticNames(
-            SystemEnvironmentPropertySource propertySource
-    ) {
-        try {
-            if (propertySource instanceof PropertySourceInfo sourceInfo) {
-                String prefix = sourceInfo.getPrefix();
-                if (prefix != null && !prefix.isBlank()) {
-                    // Prefixed system-environment mapping has additional whole-name
-                    // semantics. Skip it rather than risk a false warning.
-                    return Optional.of(List.of());
-                }
-            }
-            List<DiagnosticName> names = new ArrayList<>();
-            for (String propertyName : propertySource.getPropertyNames()) {
-                if (propertyName == null) {
-                    return Optional.empty();
-                }
-                Optional<List<DiagnosticName>> isolatedNames = isolatedDiagnosticNames(
-                        propertySource.getName(),
-                        propertyName
-                );
-                if (isolatedNames.isEmpty()) {
-                    return Optional.empty();
-                }
-                names.addAll(isolatedNames.get());
-            }
-            return Optional.of(List.copyOf(names));
-        } catch (RuntimeException ignored) {
-            return Optional.empty();
-        }
-    }
-
-    private static Optional<List<DiagnosticName>> isolatedDiagnosticNames(
-            String sourceName,
-            String propertyName
-    ) {
-        try {
-            PropertySource<?> isolatedSource = new SystemEnvironmentPropertySource(
-                    sourceName,
-                    Map.of(propertyName, Boolean.TRUE)
-            );
-            Iterator<ConfigurationPropertySource> sources =
-                    ConfigurationPropertySources.from(List.of(isolatedSource)).iterator();
-            List<DiagnosticName> names = new ArrayList<>();
-            while (sources.hasNext()) {
-                ConfigurationPropertySource source = sources.next();
-                if (!(source instanceof IterableConfigurationPropertySource iterableSource)) {
-                    continue;
-                }
-                Optional<List<ConfigurationPropertyName>> mappedNames =
-                        configurationPropertyNames(iterableSource);
-                if (mappedNames.isEmpty()) {
-                    return Optional.empty();
-                }
-                for (ConfigurationPropertyName mappedName : mappedNames.get()) {
-                    names.add(new DiagnosticName(
-                            mappedName,
-                            new DiagnosticSource(iterableSource, true)
-                    ));
-                }
-            }
-            return Optional.of(List.copyOf(names));
-        } catch (RuntimeException ignored) {
-            return Optional.empty();
-        }
     }
 
     private static Optional<Diagnostic> diagnosePropertyName(
             ConfigurationPropertyName name,
-            DiagnosticSource source
+            DiagnosticContext context
     ) {
         if (!ROOT.isAncestorOf(name)) {
             return Optional.empty();
@@ -316,7 +99,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
                 name,
                 ROOT_ELEMENTS,
                 ROOT_PROPERTIES,
-                source.systemEnvironmentMapping()
+                context.systemEnvironmentMapping()
         );
         if (rootMatchCandidate.isEmpty()) {
             return Optional.empty();
@@ -328,14 +111,14 @@ final class PrivacyConfigurationPropertyDiagnostics {
             // other near-root names may belong to provider or host extensions.
             if (propertyIndex == name.getNumberOfElements()
                     && rootMatch.expected().equals("enabled")) {
-                return suggestion(ROOT.toString(), rootMatch);
+                return typoSuggestionDiagnostic(ROOT.toString(), rootMatch);
             }
             return Optional.empty();
         }
         if (propertyIndex == name.getNumberOfElements()) {
             return rootMatch.expected().equals("enabled")
                     ? verifyCanonicalProperty(
-                            source,
+                            context,
                             ROOT.append("enabled"),
                             ROOT.toString(),
                             rootMatch
@@ -344,88 +127,93 @@ final class PrivacyConfigurationPropertyDiagnostics {
         }
         String propertyRoot = ROOT + "." + rootMatch.expected();
         return switch (rootMatch.expected()) {
-            case "enabled" -> unrecognizedFixedProperty(propertyRoot);
-            case "output" -> diagnoseFixedProperties(
+            case "enabled" -> unrecognizedPropertyBelowPrefixDiagnostic(propertyRoot);
+            case "output" -> diagnoseFixedPropertyPath(
                     name,
                     propertyIndex,
                     propertyRoot,
                     OUTPUT_PROPERTIES,
-                    source
+                    context
             );
-            case "response-inspection" -> diagnoseFixedProperties(
+            case "response-inspection" -> diagnoseFixedPropertyPath(
                     name,
                     propertyIndex,
                     propertyRoot,
                     RESPONSE_INSPECTION_PROPERTIES,
-                    source
+                    context
             );
-            case "analysis" -> diagnoseFixedProperties(
+            case "analysis" -> diagnoseFixedPropertyPath(
                     name,
                     propertyIndex,
                     propertyRoot,
                     ANALYSIS_PROPERTIES,
                     ANALYSIS_MAP_PROPERTIES,
                     ANALYSIS_INDEXED_SCALAR_PROPERTIES,
-                    source
+                    context
             );
-            case "regex" -> diagnoseRegex(
+            case "regex" -> diagnoseRegexPropertyPath(
                     name,
                     propertyIndex,
                     propertyRoot,
-                    source
+                    context
             );
-            case "tools" -> diagnoseFixedProperties(
+            case "tools" -> diagnoseFixedPropertyPath(
                     name,
                     propertyIndex,
                     propertyRoot,
                     TOOLS_PROPERTIES,
                     TOOLS_MAP_PROPERTIES,
                     Set.of(),
-                    source
+                    context
             );
             default -> Optional.empty();
         };
     }
 
-    private static Optional<Diagnostic> diagnoseFixedProperties(
+    /** Diagnoses a fixed property path whose known properties have no descendants. */
+    private static Optional<Diagnostic> diagnoseFixedPropertyPath(
             ConfigurationPropertyName name,
             int propertyIndex,
             String propertyRoot,
             List<String> knownProperties,
-            DiagnosticSource source
+            DiagnosticContext context
     ) {
-        return diagnoseFixedProperties(
+        return diagnoseFixedPropertyPath(
                 name,
                 propertyIndex,
                 propertyRoot,
                 knownProperties,
                 Set.of(),
                 Set.of(),
-                source
+                context
         );
     }
 
-    private static Optional<Diagnostic> diagnoseFixedProperties(
+    /**
+     * Diagnoses one fixed property path while treating map descendants as opaque and
+     * accepting one terminal numeric index for indexed scalar properties.
+     */
+    private static Optional<Diagnostic> diagnoseFixedPropertyPath(
             ConfigurationPropertyName name,
             int propertyIndex,
             String propertyRoot,
             List<String> knownProperties,
             Set<String> mapProperties,
             Set<String> indexedScalarProperties,
-            DiagnosticSource source
+            DiagnosticContext context
     ) {
         Optional<SegmentMatch> matchCandidate = closestSegmentMatch(
                 name,
                 propertyIndex,
                 knownProperties,
-                source.systemEnvironmentMapping()
+                context.systemEnvironmentMapping()
         );
         if (matchCandidate.isEmpty()) {
-            return unrecognizedFixedProperty(propertyRoot);
+            return unrecognizedPropertyBelowPrefixDiagnostic(propertyRoot);
         }
         SegmentMatch match = matchCandidate.get();
         if (!match.exact()) {
-            return suggestion(propertyRoot, match);
+            return typoSuggestionDiagnostic(propertyRoot, match);
         }
         int nextPropertyIndex = propertyIndex + match.consumedElements();
         if (mapProperties.contains(match.expected())) {
@@ -438,7 +226,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
                 .append(match.expected());
         if (nextPropertyIndex == name.getNumberOfElements()) {
             return verifyCanonicalProperty(
-                    source,
+                    context,
                     canonicalProperty,
                     propertyRoot,
                     match
@@ -448,45 +236,48 @@ final class PrivacyConfigurationPropertyDiagnostics {
                 && name.isNumericIndex(nextPropertyIndex)
                 && nextPropertyIndex + 1 == name.getNumberOfElements()) {
             return verifyCanonicalProperty(
-                    source,
+                    context,
                     canonicalProperty.append(name.subName(nextPropertyIndex)),
                     propertyRoot,
                     match
             );
         }
-        return unrecognizedFixedProperty(propertyRoot + "." + match.expected());
+        return unrecognizedPropertyBelowPrefixDiagnostic(
+                propertyRoot + "." + match.expected()
+        );
     }
 
-    private static Optional<Diagnostic> diagnoseRegex(
+    /** Diagnoses fixed fields and indexed rule objects below the regex property root. */
+    private static Optional<Diagnostic> diagnoseRegexPropertyPath(
             ConfigurationPropertyName name,
             int propertyIndex,
             String propertyRoot,
-            DiagnosticSource source
+            DiagnosticContext context
     ) {
         Optional<SegmentMatch> propertyMatchCandidate = closestSegmentMatch(
                 name,
                 propertyIndex,
                 REGEX_PROPERTIES,
-                source.systemEnvironmentMapping()
+                context.systemEnvironmentMapping()
         );
         if (propertyMatchCandidate.isEmpty()) {
-            return unrecognizedFixedProperty(propertyRoot);
+            return unrecognizedPropertyBelowPrefixDiagnostic(propertyRoot);
         }
         SegmentMatch propertyMatch = propertyMatchCandidate.get();
         if (!propertyMatch.exact()) {
-            return suggestion(propertyRoot, propertyMatch);
+            return typoSuggestionDiagnostic(propertyRoot, propertyMatch);
         }
         int ruleIndex = propertyIndex + propertyMatch.consumedElements();
         if (!REGEX_INDEXED_OBJECT_PROPERTIES.contains(propertyMatch.expected())) {
             return name.getNumberOfElements() <= ruleIndex
                     ? verifyCanonicalProperty(
-                            source,
+                            context,
                             ConfigurationPropertyName.of(propertyRoot)
                                     .append(propertyMatch.expected()),
                             propertyRoot,
                             propertyMatch
                     )
-                    : unrecognizedFixedProperty(
+                    : unrecognizedPropertyBelowPrefixDiagnostic(
                             propertyRoot + "." + propertyMatch.expected()
                     );
         }
@@ -494,50 +285,50 @@ final class PrivacyConfigurationPropertyDiagnostics {
             return Optional.empty();
         }
         if (!name.isNumericIndex(ruleIndex)) {
-            return unrecognizedFixedProperty(propertyRoot + ".rules");
+            return unrecognizedPropertyBelowPrefixDiagnostic(propertyRoot + ".rules");
         }
         int rulePropertyIndex = ruleIndex + 1;
         if (name.getNumberOfElements() <= rulePropertyIndex) {
             return Optional.empty();
         }
         String rulesRoot = propertyRoot + ".rules[" + dashedElement(name, ruleIndex) + "]";
-        return diagnoseFixedProperties(
+        return diagnoseFixedPropertyPath(
                 name,
                 rulePropertyIndex,
                 rulesRoot,
                 REGEX_RULE_PROPERTIES,
-                source
+                context
         );
     }
 
     private static Optional<Diagnostic> verifyCanonicalProperty(
-            DiagnosticSource source,
+            DiagnosticContext context,
             ConfigurationPropertyName canonicalName,
             String propertyRoot,
             SegmentMatch match
     ) {
-        if (canonicalPropertyResolution(source, canonicalName)
+        if (canonicalPropertyResolution(context, canonicalName)
                 != CanonicalPropertyResolution.UNRESOLVED) {
             return Optional.empty();
         }
         if (match.exact()
                 && match.consumedElements() == 1
                 && match.actual().equals(match.expected())) {
-            return unrecognizedFixedProperty(canonicalName.toString());
+            return unrecognizedPropertyBelowPrefixDiagnostic(canonicalName.toString());
         }
-        return suggestion(propertyRoot, match);
+        return typoSuggestionDiagnostic(propertyRoot, match);
     }
 
     /** Reduces a value-bearing lookup immediately to a presence-only state. */
     private static CanonicalPropertyResolution canonicalPropertyResolution(
-            DiagnosticSource source,
+            DiagnosticContext context,
             ConfigurationPropertyName canonicalName
     ) {
-        if (!source.systemEnvironmentMapping()) {
+        if (!context.systemEnvironmentMapping()) {
             return CanonicalPropertyResolution.RESOLVED;
         }
         try {
-            return source.source().getConfigurationProperty(canonicalName) != null
+            return context.source().getConfigurationProperty(canonicalName) != null
                     ? CanonicalPropertyResolution.RESOLVED
                     : CanonicalPropertyResolution.UNRESOLVED;
         } catch (RuntimeException ignored) {
@@ -545,7 +336,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
         }
     }
 
-    private static Optional<Diagnostic> suggestion(
+    private static Optional<Diagnostic> typoSuggestionDiagnostic(
             String propertyRoot,
             SegmentMatch match
     ) {
@@ -571,7 +362,9 @@ final class PrivacyConfigurationPropertyDiagnostics {
         ));
     }
 
-    private static Optional<Diagnostic> unrecognizedFixedProperty(String propertyRoot) {
+    private static Optional<Diagnostic> unrecognizedPropertyBelowPrefixDiagnostic(
+            String propertyRoot
+    ) {
         return Optional.of(new Diagnostic(
                 "Unrecognized Spring AI Privacy Guardrails configuration property detected "
                         + "below fixed prefix '"
@@ -589,7 +382,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
         return name.getElement(index, Form.UNIFORM);
     }
 
-    private static String uniform(String candidate) {
+    private static String toUniformForm(String candidate) {
         return ConfigurationPropertyName.of(candidate).getElement(0, Form.UNIFORM);
     }
 
@@ -607,7 +400,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
         int closestDistance = Integer.MAX_VALUE;
         boolean tied = false;
         for (String candidate : candidates) {
-            String candidateUniform = uniform(candidate);
+            String candidateUniform = toUniformForm(candidate);
             for (SegmentVariant variant : candidateSegmentVariants(
                     name,
                     propertyIndex,
@@ -648,7 +441,7 @@ final class PrivacyConfigurationPropertyDiagnostics {
             return Optional.empty();
         }
         String thresholdCandidate = closest.consumedElements() == 1
-                ? uniform(closest.expected())
+                ? toUniformForm(closest.expected())
                 : closest.expected();
         if (closestDistance > typoThreshold(thresholdCandidate)) {
             return Optional.empty();
@@ -762,18 +555,6 @@ final class PrivacyConfigurationPropertyDiagnostics {
             return this.message.compareTo(other.message);
         }
 
-    }
-
-    private record DiagnosticSource(
-            IterableConfigurationPropertySource source,
-            boolean systemEnvironmentMapping
-    ) {
-    }
-
-    private record DiagnosticName(
-            ConfigurationPropertyName name,
-            DiagnosticSource source
-    ) {
     }
 
     private record SegmentMatch(

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnostics.java
@@ -7,11 +7,17 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyN
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
+import org.springframework.boot.env.PropertySourceInfo;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -82,12 +88,66 @@ final class PrivacyConfigurationPropertyDiagnostics {
 
     static Set<Diagnostic> findDiagnostics(Environment environment) {
         Set<Diagnostic> diagnostics = new TreeSet<>();
-        for (ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
+        collectDiagnostics(environment, diagnostics);
+        return diagnostics;
+    }
+
+    /**
+     * Collects diagnostics on a best-effort basis. If property-source iteration or
+     * adaptation fails, already collected diagnostics are retained and startup continues.
+     */
+    private static void collectDiagnostics(
+            Environment environment,
+            Set<Diagnostic> diagnostics
+    ) {
+        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
+            return;
+        }
+        Iterator<PropertySource<?>> sources;
+        try {
+            sources = configurableEnvironment.getPropertySources().iterator();
+        } catch (RuntimeException ignored) {
+            return;
+        }
+        while (true) {
+            PropertySource<?> source;
+            try {
+                if (!sources.hasNext()) {
+                    return;
+                }
+                source = sources.next();
+            } catch (RuntimeException ignored) {
+                return;
+            }
+            collectDiagnostics(source, diagnostics);
+        }
+    }
+
+    /** Adapts each raw property source independently so one bad adapter is isolated. */
+    private static void collectDiagnostics(
+            PropertySource<?> propertySource,
+            Set<Diagnostic> diagnostics
+    ) {
+        Iterator<ConfigurationPropertySource> sources;
+        try {
+            sources = ConfigurationPropertySources.from(List.of(propertySource)).iterator();
+        } catch (RuntimeException ignored) {
+            return;
+        }
+        while (true) {
+            ConfigurationPropertySource source;
+            try {
+                if (!sources.hasNext()) {
+                    return;
+                }
+                source = sources.next();
+            } catch (RuntimeException ignored) {
+                return;
+            }
             if (source instanceof IterableConfigurationPropertySource iterableSource) {
                 collectDiagnostics(iterableSource, diagnostics);
             }
         }
-        return diagnostics;
     }
 
     /**
@@ -98,39 +158,165 @@ final class PrivacyConfigurationPropertyDiagnostics {
             IterableConfigurationPropertySource source,
             Set<Diagnostic> diagnostics
     ) {
-        Set<Diagnostic> sourceDiagnostics = new TreeSet<>();
-        Iterator<ConfigurationPropertyName> names;
-        try {
-            names = source.iterator();
-        } catch (RuntimeException ignored) {
+        Optional<List<DiagnosticName>> diagnosticNames = diagnosticNames(source);
+        if (diagnosticNames.isEmpty()) {
             return;
         }
-        while (true) {
-            ConfigurationPropertyName name;
-            try {
-                if (!names.hasNext()) {
-                    diagnostics.addAll(sourceDiagnostics);
-                    return;
-                }
-                name = names.next();
-            } catch (RuntimeException ignored) {
-                return;
+        Set<Diagnostic> sourceDiagnostics = new TreeSet<>();
+        for (DiagnosticName diagnosticName : diagnosticNames.get()) {
+            diagnosePropertyName(diagnosticName.name(), diagnosticName.source())
+                    .ifPresent(sourceDiagnostics::add);
+        }
+        diagnostics.addAll(sourceDiagnostics);
+    }
+
+    private static Optional<List<DiagnosticName>> diagnosticNames(
+            IterableConfigurationPropertySource source
+    ) {
+        try {
+            Object underlyingSource = source.getUnderlyingSource();
+            if (!(underlyingSource instanceof SystemEnvironmentPropertySource propertySource)) {
+                return nonSystemEnvironmentDiagnosticNames(source);
             }
-            if (name == null) {
-                return;
+            String name = propertySource.getName();
+            String systemEnvironment =
+                    StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
+            if (!name.equals(systemEnvironment)
+                    && !name.endsWith("-" + systemEnvironment)) {
+                return nonSystemEnvironmentDiagnosticNames(source);
             }
-            diagnosePropertyName(name).ifPresent(sourceDiagnostics::add);
+            return systemEnvironmentDiagnosticNames(propertySource);
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
         }
     }
 
-    private static Optional<Diagnostic> diagnosePropertyName(ConfigurationPropertyName name) {
+    private static Optional<List<DiagnosticName>> nonSystemEnvironmentDiagnosticNames(
+            IterableConfigurationPropertySource source
+    ) {
+        Optional<List<ConfigurationPropertyName>> names = configurationPropertyNames(source);
+        if (names.isEmpty()) {
+            return Optional.empty();
+        }
+        List<DiagnosticName> diagnosticNames = new ArrayList<>(names.get().size());
+        for (ConfigurationPropertyName name : names.get()) {
+            diagnosticNames.add(new DiagnosticName(
+                    name,
+                    new DiagnosticSource(source, false)
+            ));
+        }
+        return Optional.of(List.copyOf(diagnosticNames));
+    }
+
+    private static Optional<List<ConfigurationPropertyName>> configurationPropertyNames(
+            IterableConfigurationPropertySource source
+    ) {
+        List<ConfigurationPropertyName> names = new ArrayList<>();
+        Iterator<ConfigurationPropertyName> iterator;
+        try {
+            iterator = source.iterator();
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+        while (true) {
+            try {
+                if (!iterator.hasNext()) {
+                    return Optional.of(List.copyOf(names));
+                }
+                ConfigurationPropertyName name = iterator.next();
+                if (name == null) {
+                    return Optional.empty();
+                }
+                names.add(name);
+            } catch (RuntimeException ignored) {
+                return Optional.empty();
+            }
+        }
+    }
+
+    /**
+     * Gives each raw variable a one-entry resolver. This mirrors Boot's lookup without
+     * reading the real value and prevents one valid alias from hiding another bad name.
+     */
+    private static Optional<List<DiagnosticName>> systemEnvironmentDiagnosticNames(
+            SystemEnvironmentPropertySource propertySource
+    ) {
+        try {
+            if (propertySource instanceof PropertySourceInfo sourceInfo) {
+                String prefix = sourceInfo.getPrefix();
+                if (prefix != null && !prefix.isBlank()) {
+                    // Prefixed system-environment mapping has additional whole-name
+                    // semantics. Skip it rather than risk a false warning.
+                    return Optional.of(List.of());
+                }
+            }
+            List<DiagnosticName> names = new ArrayList<>();
+            for (String propertyName : propertySource.getPropertyNames()) {
+                if (propertyName == null) {
+                    return Optional.empty();
+                }
+                Optional<List<DiagnosticName>> isolatedNames = isolatedDiagnosticNames(
+                        propertySource.getName(),
+                        propertyName
+                );
+                if (isolatedNames.isEmpty()) {
+                    return Optional.empty();
+                }
+                names.addAll(isolatedNames.get());
+            }
+            return Optional.of(List.copyOf(names));
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<List<DiagnosticName>> isolatedDiagnosticNames(
+            String sourceName,
+            String propertyName
+    ) {
+        try {
+            PropertySource<?> isolatedSource = new SystemEnvironmentPropertySource(
+                    sourceName,
+                    Map.of(propertyName, Boolean.TRUE)
+            );
+            Iterator<ConfigurationPropertySource> sources =
+                    ConfigurationPropertySources.from(List.of(isolatedSource)).iterator();
+            List<DiagnosticName> names = new ArrayList<>();
+            while (sources.hasNext()) {
+                ConfigurationPropertySource source = sources.next();
+                if (!(source instanceof IterableConfigurationPropertySource iterableSource)) {
+                    continue;
+                }
+                Optional<List<ConfigurationPropertyName>> mappedNames =
+                        configurationPropertyNames(iterableSource);
+                if (mappedNames.isEmpty()) {
+                    return Optional.empty();
+                }
+                for (ConfigurationPropertyName mappedName : mappedNames.get()) {
+                    names.add(new DiagnosticName(
+                            mappedName,
+                            new DiagnosticSource(iterableSource, true)
+                    ));
+                }
+            }
+            return Optional.of(List.copyOf(names));
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<Diagnostic> diagnosePropertyName(
+            ConfigurationPropertyName name,
+            DiagnosticSource source
+    ) {
         if (!ROOT.isAncestorOf(name)) {
             return Optional.empty();
         }
         Optional<SegmentMatch> rootMatchCandidate = closestSegmentMatch(
                 name,
                 ROOT_ELEMENTS,
-                ROOT_PROPERTIES
+                ROOT_PROPERTIES,
+                source.systemEnvironmentMapping()
         );
         if (rootMatchCandidate.isEmpty()) {
             return Optional.empty();
@@ -147,7 +333,14 @@ final class PrivacyConfigurationPropertyDiagnostics {
             return Optional.empty();
         }
         if (propertyIndex == name.getNumberOfElements()) {
-            return Optional.empty();
+            return rootMatch.expected().equals("enabled")
+                    ? verifyCanonicalProperty(
+                            source,
+                            ROOT.append("enabled"),
+                            ROOT.toString(),
+                            rootMatch
+                    )
+                    : Optional.empty();
         }
         String propertyRoot = ROOT + "." + rootMatch.expected();
         return switch (rootMatch.expected()) {
@@ -156,13 +349,15 @@ final class PrivacyConfigurationPropertyDiagnostics {
                     name,
                     propertyIndex,
                     propertyRoot,
-                    OUTPUT_PROPERTIES
+                    OUTPUT_PROPERTIES,
+                    source
             );
             case "response-inspection" -> diagnoseFixedProperties(
                     name,
                     propertyIndex,
                     propertyRoot,
-                    RESPONSE_INSPECTION_PROPERTIES
+                    RESPONSE_INSPECTION_PROPERTIES,
+                    source
             );
             case "analysis" -> diagnoseFixedProperties(
                     name,
@@ -170,16 +365,23 @@ final class PrivacyConfigurationPropertyDiagnostics {
                     propertyRoot,
                     ANALYSIS_PROPERTIES,
                     ANALYSIS_MAP_PROPERTIES,
-                    ANALYSIS_INDEXED_SCALAR_PROPERTIES
+                    ANALYSIS_INDEXED_SCALAR_PROPERTIES,
+                    source
             );
-            case "regex" -> diagnoseRegex(name, propertyIndex, propertyRoot);
+            case "regex" -> diagnoseRegex(
+                    name,
+                    propertyIndex,
+                    propertyRoot,
+                    source
+            );
             case "tools" -> diagnoseFixedProperties(
                     name,
                     propertyIndex,
                     propertyRoot,
                     TOOLS_PROPERTIES,
                     TOOLS_MAP_PROPERTIES,
-                    Set.of()
+                    Set.of(),
+                    source
             );
             default -> Optional.empty();
         };
@@ -189,7 +391,8 @@ final class PrivacyConfigurationPropertyDiagnostics {
             ConfigurationPropertyName name,
             int propertyIndex,
             String propertyRoot,
-            List<String> knownProperties
+            List<String> knownProperties,
+            DiagnosticSource source
     ) {
         return diagnoseFixedProperties(
                 name,
@@ -197,7 +400,8 @@ final class PrivacyConfigurationPropertyDiagnostics {
                 propertyRoot,
                 knownProperties,
                 Set.of(),
-                Set.of()
+                Set.of(),
+                source
         );
     }
 
@@ -207,12 +411,14 @@ final class PrivacyConfigurationPropertyDiagnostics {
             String propertyRoot,
             List<String> knownProperties,
             Set<String> mapProperties,
-            Set<String> indexedScalarProperties
+            Set<String> indexedScalarProperties,
+            DiagnosticSource source
     ) {
         Optional<SegmentMatch> matchCandidate = closestSegmentMatch(
                 name,
                 propertyIndex,
-                knownProperties
+                knownProperties,
+                source.systemEnvironmentMapping()
         );
         if (matchCandidate.isEmpty()) {
             return unrecognizedFixedProperty(propertyRoot);
@@ -222,14 +428,31 @@ final class PrivacyConfigurationPropertyDiagnostics {
             return suggestion(propertyRoot, match);
         }
         int nextPropertyIndex = propertyIndex + match.consumedElements();
-        if (nextPropertyIndex == name.getNumberOfElements()
-                || mapProperties.contains(match.expected())) {
+        if (mapProperties.contains(match.expected())) {
+            // Dynamic map keys are application-controlled and may contain sensitive
+            // identifiers. Leave aggregate binding details to Boot and do not diagnose
+            // descendants from this best-effort scanner.
             return Optional.empty();
+        }
+        ConfigurationPropertyName canonicalProperty = ConfigurationPropertyName.of(propertyRoot)
+                .append(match.expected());
+        if (nextPropertyIndex == name.getNumberOfElements()) {
+            return verifyCanonicalProperty(
+                    source,
+                    canonicalProperty,
+                    propertyRoot,
+                    match
+            );
         }
         if (indexedScalarProperties.contains(match.expected())
                 && name.isNumericIndex(nextPropertyIndex)
                 && nextPropertyIndex + 1 == name.getNumberOfElements()) {
-            return Optional.empty();
+            return verifyCanonicalProperty(
+                    source,
+                    canonicalProperty.append(name.subName(nextPropertyIndex)),
+                    propertyRoot,
+                    match
+            );
         }
         return unrecognizedFixedProperty(propertyRoot + "." + match.expected());
     }
@@ -237,12 +460,14 @@ final class PrivacyConfigurationPropertyDiagnostics {
     private static Optional<Diagnostic> diagnoseRegex(
             ConfigurationPropertyName name,
             int propertyIndex,
-            String propertyRoot
+            String propertyRoot,
+            DiagnosticSource source
     ) {
         Optional<SegmentMatch> propertyMatchCandidate = closestSegmentMatch(
                 name,
                 propertyIndex,
-                REGEX_PROPERTIES
+                REGEX_PROPERTIES,
+                source.systemEnvironmentMapping()
         );
         if (propertyMatchCandidate.isEmpty()) {
             return unrecognizedFixedProperty(propertyRoot);
@@ -254,7 +479,13 @@ final class PrivacyConfigurationPropertyDiagnostics {
         int ruleIndex = propertyIndex + propertyMatch.consumedElements();
         if (!REGEX_INDEXED_OBJECT_PROPERTIES.contains(propertyMatch.expected())) {
             return name.getNumberOfElements() <= ruleIndex
-                    ? Optional.empty()
+                    ? verifyCanonicalProperty(
+                            source,
+                            ConfigurationPropertyName.of(propertyRoot)
+                                    .append(propertyMatch.expected()),
+                            propertyRoot,
+                            propertyMatch
+                    )
                     : unrecognizedFixedProperty(
                             propertyRoot + "." + propertyMatch.expected()
                     );
@@ -269,21 +500,68 @@ final class PrivacyConfigurationPropertyDiagnostics {
         if (name.getNumberOfElements() <= rulePropertyIndex) {
             return Optional.empty();
         }
-        String rulesRoot = propertyRoot + ".rules[" + element(name, ruleIndex) + "]";
+        String rulesRoot = propertyRoot + ".rules[" + dashedElement(name, ruleIndex) + "]";
         return diagnoseFixedProperties(
                 name,
                 rulePropertyIndex,
                 rulesRoot,
-                REGEX_RULE_PROPERTIES
+                REGEX_RULE_PROPERTIES,
+                source
         );
+    }
+
+    private static Optional<Diagnostic> verifyCanonicalProperty(
+            DiagnosticSource source,
+            ConfigurationPropertyName canonicalName,
+            String propertyRoot,
+            SegmentMatch match
+    ) {
+        if (canonicalPropertyResolution(source, canonicalName)
+                != CanonicalPropertyResolution.UNRESOLVED) {
+            return Optional.empty();
+        }
+        if (match.exact()
+                && match.consumedElements() == 1
+                && match.actual().equals(match.expected())) {
+            return unrecognizedFixedProperty(canonicalName.toString());
+        }
+        return suggestion(propertyRoot, match);
+    }
+
+    /** Reduces a value-bearing lookup immediately to a presence-only state. */
+    private static CanonicalPropertyResolution canonicalPropertyResolution(
+            DiagnosticSource source,
+            ConfigurationPropertyName canonicalName
+    ) {
+        if (!source.systemEnvironmentMapping()) {
+            return CanonicalPropertyResolution.RESOLVED;
+        }
+        try {
+            return source.source().getConfigurationProperty(canonicalName) != null
+                    ? CanonicalPropertyResolution.RESOLVED
+                    : CanonicalPropertyResolution.UNRESOLVED;
+        } catch (RuntimeException ignored) {
+            return CanonicalPropertyResolution.INDETERMINATE;
+        }
     }
 
     private static Optional<Diagnostic> suggestion(
             String propertyRoot,
             SegmentMatch match
     ) {
-        String actualName = propertyRoot + "." + match.actual();
         String expectedName = propertyRoot + "." + match.expected();
+        if (match.consumedElements() > 1) {
+            return Optional.of(new Diagnostic(
+                    "Unrecognized Spring AI Privacy Guardrails configuration property detected "
+                            + "below fixed prefix '"
+                            + propertyRoot
+                            + "'. Did you mean '"
+                            + expectedName
+                            + "'? The unrecognized property name and configuration value were "
+                            + "omitted from this diagnostic."
+            ));
+        }
+        String actualName = propertyRoot + "." + match.actual();
         return Optional.of(new Diagnostic(
                 "Unrecognized Spring AI Privacy Guardrails configuration property '"
                         + actualName
@@ -303,8 +581,16 @@ final class PrivacyConfigurationPropertyDiagnostics {
         ));
     }
 
-    private static String element(ConfigurationPropertyName name, int index) {
+    private static String dashedElement(ConfigurationPropertyName name, int index) {
         return name.getElement(index, Form.DASHED);
+    }
+
+    private static String uniformElement(ConfigurationPropertyName name, int index) {
+        return name.getElement(index, Form.UNIFORM);
+    }
+
+    private static String uniform(String candidate) {
+        return ConfigurationPropertyName.of(candidate).getElement(0, Form.UNIFORM);
     }
 
     /**
@@ -314,24 +600,37 @@ final class PrivacyConfigurationPropertyDiagnostics {
     private static Optional<SegmentMatch> closestSegmentMatch(
             ConfigurationPropertyName name,
             int propertyIndex,
-            List<String> candidates
+            List<String> candidates,
+            boolean systemEnvironmentMapping
     ) {
         SegmentMatch closest = null;
         int closestDistance = Integer.MAX_VALUE;
         boolean tied = false;
         for (String candidate : candidates) {
-            for (SegmentVariant variant : candidateSegmentVariants(name, propertyIndex, candidate)) {
-                if (variant.actual().equals(candidate)) {
+            String candidateUniform = uniform(candidate);
+            for (SegmentVariant variant : candidateSegmentVariants(
+                    name,
+                    propertyIndex,
+                    candidate,
+                    systemEnvironmentMapping
+            )) {
+                String candidateComparison = variant.consumedElements() == 1
+                        ? candidateUniform
+                        : candidate;
+                if (variant.comparison().equals(candidateComparison)) {
                     return Optional.of(new SegmentMatch(
-                            variant.actual(),
+                            variant.display(),
                             candidate,
                             variant.consumedElements(),
                             true
                     ));
                 }
-                int distance = levenshteinDistance(variant.actual(), candidate);
+                int distance = levenshteinDistance(
+                        variant.comparison(),
+                        candidateComparison
+                );
                 SegmentMatch match = new SegmentMatch(
-                        variant.actual(),
+                        variant.display(),
                         candidate,
                         variant.consumedElements(),
                         false
@@ -345,44 +644,60 @@ final class PrivacyConfigurationPropertyDiagnostics {
                 }
             }
         }
-        if (tied || closest == null || closestDistance > typoThreshold(closest.expected())) {
+        if (tied || closest == null) {
+            return Optional.empty();
+        }
+        String thresholdCandidate = closest.consumedElements() == 1
+                ? uniform(closest.expected())
+                : closest.expected();
+        if (closestDistance > typoThreshold(thresholdCandidate)) {
             return Optional.empty();
         }
         return Optional.of(closest);
     }
 
     /**
-     * Builds comparable forms for one dashed element and for the equivalent element
-     * sequence produced from relaxed operating-system environment variable names.
+     * Builds safe display and binding-compatible comparison forms for one element and
+     * for the legacy sequence produced from operating-system environment variable names.
      */
     private static List<SegmentVariant> candidateSegmentVariants(
             ConfigurationPropertyName name,
             int propertyIndex,
-            String candidate
+            String candidate,
+            boolean systemEnvironmentMapping
     ) {
         List<SegmentVariant> variants = new ArrayList<>(2);
-        String singleElement = element(name, propertyIndex);
-        variants.add(new SegmentVariant(singleElement, 1));
-
         int candidateElements = candidate.split("-").length;
-        if (candidateElements == 1
+        String singleDisplay = dashedElement(name, propertyIndex);
+        variants.add(new SegmentVariant(
+                singleDisplay,
+                uniformElement(name, propertyIndex),
+                1
+        ));
+
+        if (!systemEnvironmentMapping
+                || candidateElements == 1
                 || propertyIndex + candidateElements > name.getNumberOfElements()) {
             return variants;
         }
-        StringBuilder joinedElements = new StringBuilder();
+        StringBuilder joinedDisplay = new StringBuilder();
         for (int offset = 0; offset < candidateElements; offset++) {
             int elementIndex = propertyIndex + offset;
             if (name.isNumericIndex(elementIndex)) {
                 return variants;
             }
-            if (!joinedElements.isEmpty()) {
-                joinedElements.append('-');
+            if (!joinedDisplay.isEmpty()) {
+                joinedDisplay.append('-');
             }
-            joinedElements.append(element(name, elementIndex));
+            joinedDisplay.append(dashedElement(name, elementIndex));
         }
-        String joined = joinedElements.toString();
-        if (!joined.equals(singleElement)) {
-            variants.add(new SegmentVariant(joined, candidateElements));
+        String display = joinedDisplay.toString();
+        if (!display.equals(singleDisplay)) {
+            variants.add(new SegmentVariant(
+                    display,
+                    display,
+                    candidateElements
+            ));
         }
         return variants;
     }
@@ -449,6 +764,18 @@ final class PrivacyConfigurationPropertyDiagnostics {
 
     }
 
+    private record DiagnosticSource(
+            IterableConfigurationPropertySource source,
+            boolean systemEnvironmentMapping
+    ) {
+    }
+
+    private record DiagnosticName(
+            ConfigurationPropertyName name,
+            DiagnosticSource source
+    ) {
+    }
+
     private record SegmentMatch(
             String actual,
             String expected,
@@ -457,7 +784,19 @@ final class PrivacyConfigurationPropertyDiagnostics {
     ) {
     }
 
-    private record SegmentVariant(String actual, int consumedElements) {
+    private record SegmentVariant(
+            String display,
+            String comparison,
+            int consumedElements
+    ) {
+    }
+
+    private enum CanonicalPropertyResolution {
+
+        RESOLVED,
+        UNRESOLVED,
+        INDETERMINATE
+
     }
 
 }

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnosticsTest.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyConfigurationPropertyDiagnosticsTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.env.PropertySourceInfo;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -220,19 +221,253 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
     }
 
     @Test
-    void recognizesDashedFixedPropertiesFromSystemEnvironmentNames(CapturedOutput output) {
+    void recognizesCamelCaseFixedPropertyNames(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.enabled=true",
+                        "spring.ai.privacy.responseInspection.maxCharacters=8",
+                        "spring.ai.privacy.analysis.minimumScore=0.5",
+                        "spring.ai.privacy.output.blockExceptionMessage=safe-message",
+                        "spring.ai.privacy.regex.rules[0].entityType=CUSTOMER_ID",
+                        "spring.ai.privacy.regex.rules[0].pattern=\\bCUST-\\d{6}\\b",
+                        "spring.ai.privacy.regex.rules[0].validatorId=customer-id-check"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+                    PrivacyGuardrailsProperties properties = context.getBean(
+                            PrivacyGuardrailsProperties.class
+                    );
+                    assertThat(properties.getResponseInspection().getMaxCharacters()).isEqualTo(8);
+                    assertThat(properties.getAnalysis().getMinimumScore()).isEqualTo(0.5);
+                    assertThat(properties.getOutput().getBlockExceptionMessage())
+                            .isEqualTo("safe-message");
+                    assertThat(properties.getRegex().getRules()).singleElement()
+                            .satisfies(rule -> {
+                                assertThat(rule.getEntityType()).isEqualTo("CUSTOMER_ID");
+                                assertThat(rule.getValidatorId()).isEqualTo("customer-id-check");
+                            });
+                    assertThat(output)
+                            .doesNotContain(
+                                    "Unrecognized Spring AI Privacy Guardrails "
+                                            + "configuration property"
+                            )
+                            .doesNotContain("safe-message");
+                });
+    }
+
+    @Test
+    void recognizesCanonicalSystemEnvironmentNames(CapturedOutput output) {
         withSystemEnvironment(Map.of(
-                "SPRING_AI_PRIVACY_RESPONSE_INSPECTION_MAX_CHARACTERS", "8",
-                "SPRING_AI_PRIVACY_ANALYSIS_MINIMUM_SCORE", "0.5",
-                "SPRING_AI_PRIVACY_ANALYSIS_INCLUDED_ENTITY_TYPES_0", "CUSTOMER_ID",
-                "SPRING_AI_PRIVACY_ANALYSIS_SUPPLEMENTAL_PROVIDERS_0", "custom-provider",
-                "SPRING_AI_PRIVACY_OUTPUT_BLOCK_EXCEPTION_MESSAGE", "safe-message",
-                "SPRING_AI_PRIVACY_REGEX_RULES_0_ENTITY_TYPE", "CUSTOMER_ID"
+                "SPRING_AI_PRIVACY_ENABLED", "true",
+                "SPRING_AI_PRIVACY_RESPONSEINSPECTION_MAXCHARACTERS", "8",
+                "SPRING_AI_PRIVACY_ANALYSIS_MINIMUMSCORE", "0.5",
+                "SPRING_AI_PRIVACY_ANALYSIS_INCLUDEDENTITYTYPES_0", "EMAIL_ADDRESS",
+                "SPRING_AI_PRIVACY_OUTPUT_BLOCKEXCEPTIONMESSAGE", "safe-message",
+                "SPRING_AI_PRIVACY_REGEX_RULES_0_ENTITYTYPE", "CUSTOMER_ID",
+                "SPRING_AI_PRIVACY_REGEX_RULES_0_PATTERN", "\\bCUST-\\d{6}\\b",
+                "SPRING_AI_PRIVACY_REGEX_RULES_0_VALIDATORID", "customer-id-check"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+            PrivacyGuardrailsProperties properties = context.getBean(
+                    PrivacyGuardrailsProperties.class
+            );
+            assertThat(properties.getResponseInspection().getMaxCharacters()).isEqualTo(8);
+            assertThat(properties.getAnalysis().getMinimumScore()).isEqualTo(0.5);
+            assertThat(properties.getAnalysis().getIncludedEntityTypes())
+                    .containsExactly("EMAIL_ADDRESS");
+            assertThat(properties.getOutput().getBlockExceptionMessage())
+                    .isEqualTo("safe-message");
+            assertThat(properties.getRegex().getRules()).singleElement()
+                    .satisfies(rule -> {
+                        assertThat(rule.getEntityType()).isEqualTo("CUSTOMER_ID");
+                        assertThat(rule.getValidatorId()).isEqualTo("customer-id-check");
+                    });
+            assertThat(output)
+                    .doesNotContain(
+                            "Unrecognized Spring AI Privacy Guardrails configuration property"
+                    )
+                    .doesNotContain("safe-message");
+        });
+    }
+
+    @Test
+    void warnsForTyposInCanonicalSystemEnvironmentNames(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_RESPONSEINSPECTION_MAXCHARACTERSS", "8",
+                "SPRING_AI_PRIVACY_ANALYSIS_PROVIDERMINIMUMSCOREZ_CUSTOMPROVIDER", "0.75",
+                "SPRING_AI_PRIVACY_REGEX_RULES_0_VALIDATORIDD", "synthetic-sensitive-value"
         )).run(context -> {
             assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
             assertThat(output)
+                    .contains("'spring.ai.privacy.response-inspection.maxcharacterss'")
+                    .contains("'spring.ai.privacy.response-inspection.max-characters'")
+                    .contains("'spring.ai.privacy.analysis.providerminimumscorez'")
+                    .contains("'spring.ai.privacy.analysis.provider-minimum-scores'")
+                    .contains("'spring.ai.privacy.regex.rules[0].validatoridd'")
+                    .contains("'spring.ai.privacy.regex.rules[0].validator-id'")
+                    .doesNotContain("customprovider")
+                    .doesNotContain("synthetic-sensitive-value");
+        });
+    }
+
+    @Test
+    void recognizesRelaxedDynamicSegments(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_ANALYSIS_PROVIDERMINIMUMSCORES_ENVPROVIDER", "0.75",
+                "SPRING_AI_PRIVACY_ANALYSIS_ENTITYALIASES_EXTERNALLABEL", "CUSTOMER_ID",
+                "SPRING_AI_PRIVACY_TOOLS_DISCLOSURES_CUSTOMERLOOKUP_0", "CUSTOMER_ID"
+        )).withPropertyValues(
+                "spring.ai.privacy.analysis.providerMinimumScores.customProvider=0.75",
+                "spring.ai.privacy.analysis.entityAliases.externalLabel=CUSTOMER_ID",
+                "spring.ai.privacy.tools.disclosures.customerLookup[0]=CUSTOMER_ID"
+        ).run(context -> {
+            assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+            assertThat(output)
+                    .doesNotContain(
+                            "Unrecognized Spring AI Privacy Guardrails configuration property"
+                    )
+                    .doesNotContain("customProvider")
+                    .doesNotContain("ENVPROVIDER");
+        });
+    }
+
+    @Test
+    void doesNotTreatDottedPropertyNamesAsLegacyEnvironmentNames(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.analysis.minimum.score=0.5",
+                        "spring.ai.privacy.output.block.exception.message=synthetic-sensitive-value",
+                        "spring.ai.privacy.regex.rules[0].entity.type=CUSTOMER_ID"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .contains("below fixed prefix 'spring.ai.privacy.analysis'")
+                            .contains("below fixed prefix 'spring.ai.privacy.output'")
+                            .contains("'spring.ai.privacy.regex.rules[0].entity'")
+                            .contains("'spring.ai.privacy.regex.rules[0].entity-type'")
+                            .doesNotContain("synthetic-sensitive-value")
+                            .doesNotContain("CUSTOMER_ID");
+                });
+    }
+
+    @Test
+    void warnsForANestedTypoBelowACamelCaseRoot(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withPropertyValues(
+                        "spring.ai.privacy.responseInspection.maxCharacterss="
+                                + "synthetic-sensitive-value"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .contains(
+                                    "'spring.ai.privacy.response-inspection.maxcharacterss'"
+                            )
+                            .contains(
+                                    "'spring.ai.privacy.response-inspection.max-characters'"
+                            )
+                            .doesNotContain("synthetic-sensitive-value");
+                });
+    }
+
+    @Test
+    void recognizesLegacyCompatibleSystemEnvironmentNames(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_ENABLED", "true",
+                "SPRING_AI_PRIVACY_RESPONSE_INSPECTION_MAX_CHARACTERS", "8",
+                "SPRING_AI_PRIVACY_ANALYSIS_MINIMUM_SCORE", "0.5",
+                "SPRING_AI_PRIVACY_ANALYSIS_INCLUDED_ENTITY_TYPES_0", "EMAIL_ADDRESS",
+                "SPRING_AI_PRIVACY_OUTPUT_BLOCK_EXCEPTION_MESSAGE", "safe-message",
+                "SPRING_AI_PRIVACY_REGEX_RULES_0_ENTITY_TYPE", "EMAIL_ADDRESS"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+            PrivacyGuardrailsProperties properties = context.getBean(
+                    PrivacyGuardrailsProperties.class
+            );
+            assertThat(properties.getResponseInspection().getMaxCharacters()).isEqualTo(8);
+            assertThat(properties.getAnalysis().getMinimumScore()).isEqualTo(0.5);
+            assertThat(properties.getAnalysis().getIncludedEntityTypes())
+                    .containsExactly("EMAIL_ADDRESS");
+            assertThat(properties.getOutput().getBlockExceptionMessage())
+                    .isEqualTo("safe-message");
+            assertThat(properties.getRegex().getRules()).singleElement()
+                    .satisfies(rule ->
+                            assertThat(rule.getEntityType()).isEqualTo("EMAIL_ADDRESS"));
+            assertThat(output)
                     .doesNotContain("Unrecognized Spring AI Privacy Guardrails configuration property")
                     .doesNotContain("safe-message");
+        });
+    }
+
+    @Test
+    void recognizesStandardAndLegacyEnvironmentNamesInTheSameSource(
+            CapturedOutput output
+    ) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_ENABLED", "true",
+                "SPRING_AI_PRIVACY_RESPONSEINSPECTION_MAXCHARACTERS", "8",
+                "SPRING_AI_PRIVACY_RESPONSE_INSPECTION_MAX_MEDIA_BYTES", "9"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+            PrivacyGuardrailsProperties properties = context.getBean(
+                    PrivacyGuardrailsProperties.class
+            );
+            assertThat(properties.getResponseInspection().getMaxCharacters()).isEqualTo(8);
+            assertThat(properties.getResponseInspection().getMaxMediaBytes()).isEqualTo(9);
+            assertThat(output).doesNotContain(
+                    "Unrecognized Spring AI Privacy Guardrails configuration property"
+            );
+        });
+    }
+
+    @Test
+    void warnsWhenStandardRootAndLegacyPropertyFormsAreMixed(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_ENABLED", "true",
+                "SPRING_AI_PRIVACY_RESPONSEINSPECTION_MAX_CHARACTERS", "87654321"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+            assertThat(context.getBean(PrivacyGuardrailsProperties.class)
+                    .getResponseInspection()
+                    .getMaxCharacters()).isEqualTo(new PrivacyGuardrailsProperties()
+                            .getResponseInspection()
+                            .getMaxCharacters());
+            assertThat(output)
+                    .contains("Did you mean "
+                            + "'spring.ai.privacy.response-inspection.max-characters'?")
+                    .doesNotContain("87654321");
+        });
+    }
+
+    @Test
+    void validAliasDoesNotHideAnInvalidEnvironmentName(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY_ENABLED", "true",
+                "SPRING_AI_PRIVACY_RESPONSE__INSPECTION_MAX_CHARACTERS", "87654321",
+                "SPRING_AI_PRIVACY_RESPONSE_INSPECTION_MAX_CHARACTERS", "8"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+            assertThat(context.getBean(PrivacyGuardrailsProperties.class)
+                    .getResponseInspection()
+                    .getMaxCharacters()).isEqualTo(8);
+            assertThat(output)
+                    .contains("Did you mean "
+                            + "'spring.ai.privacy.response-inspection.max-characters'?")
+                    .doesNotContain("87654321");
+        });
+    }
+
+    @Test
+    void doesNotWarnWhenRepeatedSeparatorStillBinds(CapturedOutput output) {
+        withSystemEnvironment(Map.of(
+                "SPRING_AI_PRIVACY__ENABLED", "true"
+        )).run(context -> {
+            assertThat(context).hasNotFailed().hasSingleBean(PrivacyService.class);
+            assertThat(context.getBean(PrivacyGuardrailsProperties.class).isEnabled()).isTrue();
+            assertThat(output).doesNotContain(
+                    "Unrecognized Spring AI Privacy Guardrails configuration property"
+            );
         });
     }
 
@@ -248,14 +483,18 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
         )).run(context -> {
             assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
             assertThat(output)
-                    .contains("'spring.ai.privacy.response-inspection.max-characterss'")
                     .contains("'spring.ai.privacy.response-inspection.max-characters'")
-                    .contains("'spring.ai.privacy.output.block-exception-mesage'")
                     .contains("'spring.ai.privacy.output.block-exception-message'")
-                    .contains("'spring.ai.privacy.regex.rules[0].capture-gropu'")
                     .contains("'spring.ai.privacy.regex.rules[0].capture-group'")
                     .contains("'spring.ai.privacy.enabledddd'")
                     .contains("'spring.ai.privacy.enabled'")
+                    .doesNotContain(
+                            "'spring.ai.privacy.response-inspection.max-characterss'"
+                    )
+                    .doesNotContain(
+                            "'spring.ai.privacy.output.block-exception-mesage'"
+                    )
+                    .doesNotContain("'spring.ai.privacy.regex.rules[0].capture-gropu'")
                     .doesNotContain("synthetic-sensitive-value");
         });
     }
@@ -300,7 +539,9 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
     }
 
     @Test
-    void ignoresDynamicSystemEnvironmentSegmentsAndTheirValues(CapturedOutput output) {
+    void ignoresDynamicSystemEnvironmentSegmentsAndTheirValues(
+            CapturedOutput output
+    ) {
         withSystemEnvironment(Map.of(
                 "SPRING_AI_PRIVACY_ANALYSIS_PROVIDER_MINIMUM_SCORES_CUSTOM_PROVIDER", "0.75",
                 "SPRING_AI_PRIVACY_ANALYSIS_ENTITY_ALIASES_EXTERNAL_LABEL", "CUSTOMER_ID",
@@ -310,7 +551,12 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
         )).run(context -> {
             assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
             assertThat(output)
-                    .doesNotContain("Unrecognized Spring AI Privacy Guardrails configuration property")
+                    .doesNotContain(
+                            "Unrecognized Spring AI Privacy Guardrails configuration property"
+                    )
+                    .doesNotContain("custom-provider")
+                    .doesNotContain("external-label")
+                    .doesNotContain("customer-lookup")
                     .doesNotContain("synthetic-secret-one")
                     .doesNotContain("synthetic-secret-two");
         });
@@ -329,6 +575,45 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
                             .contains("'spring.ai.privacy.enabledddd'. Did you mean ")
                             .contains("'spring.ai.privacy.enabled'?")
                             .doesNotContain(ThrowingEnumerablePropertySource.SENSITIVE_MESSAGE);
+                });
+    }
+
+    @Test
+    void skipsOnlyAPropertySourceThatCannotBeAdapted(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withInitializer(context -> context.getEnvironment().getPropertySources().addFirst(
+                        new ThrowingAdaptationPropertySource()
+                ))
+                .withPropertyValues("spring.ai.privacy.enabledddd=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .contains("'spring.ai.privacy.enabledddd'. Did you mean ")
+                            .contains("'spring.ai.privacy.enabled'?")
+                            .doesNotContain(ThrowingAdaptationPropertySource.SENSITIVE_MESSAGE);
+                });
+    }
+
+    @Test
+    void skipsSystemEnvironmentSourcesWithAnApplicationPrefix(CapturedOutput output) {
+        this.diagnosticsRunner
+                .withInitializer(context -> context.getEnvironment().getPropertySources().addFirst(
+                        new PrefixedSystemEnvironmentPropertySource(
+                                "privacy-app",
+                                Map.of(
+                                        "PRIVACYAPP_SPRING_AI_PRIVACY_ENABLEDDDD",
+                                        "synthetic-sensitive-value"
+                                )
+                        )
+                ))
+                .run(context -> {
+                    assertThat(context).hasNotFailed().doesNotHaveBean(PrivacyService.class);
+                    assertThat(output)
+                            .doesNotContain(
+                                    "Unrecognized Spring AI Privacy Guardrails "
+                                            + "configuration property"
+                            )
+                            .doesNotContain("synthetic-sensitive-value");
                 });
     }
 
@@ -514,6 +799,58 @@ class PrivacyConfigurationPropertyDiagnosticsTest {
         @Override
         public Object getProperty(String name) {
             return null;
+        }
+
+    }
+
+    private static final class ThrowingAdaptationPropertySource
+            extends EnumerablePropertySource<Object> {
+
+        private static final String SENSITIVE_MESSAGE = "synthetic-adaptation-detail";
+
+        private ThrowingAdaptationPropertySource() {
+            super("throwing-adaptation-property-source", new Object());
+        }
+
+        @Override
+        public Object getSource() {
+            throw new IllegalStateException(SENSITIVE_MESSAGE);
+        }
+
+        @Override
+        public String[] getPropertyNames() {
+            return new String[] {"spring.ai.privacy.enabled"};
+        }
+
+        @Override
+        public boolean containsProperty(String name) {
+            return false;
+        }
+
+        @Override
+        public Object getProperty(String name) {
+            return null;
+        }
+
+    }
+
+    private static final class PrefixedSystemEnvironmentPropertySource
+            extends SystemEnvironmentPropertySource
+            implements PropertySourceInfo {
+
+        private final String prefix;
+
+        private PrefixedSystemEnvironmentPropertySource(
+                String prefix,
+                Map<String, Object> environment
+        ) {
+            super(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, environment);
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String getPrefix() {
+            return this.prefix;
         }
 
     }


### PR DESCRIPTION
## Summary

Configuration diagnostics introduced in PR #6 could diverge from Spring Boot relaxed binding for camelCase property names and system-environment aliases.

Valid configuration forms could produce warnings, while some dotted or mixed environment forms that do not bind could be treated as valid.

This change carries source-mapping context into property-name diagnostics, uses binding-compatible comparisons for relaxed property names, and verifies canonical resolution for system-environment candidates.

Environment variables are mapped independently so one valid alias cannot hide another invalid name.

Provider extensions and dynamic map keys remain outside the diagnostic scope.

Diagnostics skip prefixed system-environment sources rather than risk false warnings.

Diagnostics remain warning-only, never expose configuration values or dynamic keys, and never prevent application startup.

Property-source candidate collection is separated from property-path diagnosis.

## Related Issue

Follow-up to PR #6, which resolved Issue #4.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.