### PR TITLE
fix: preserve release tag when publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,8 +434,15 @@ jobs:
           jq -n \
             --arg name "$release_name" \
             --arg body "$release_body" \
-            '{name: $name, body: $body, draft: false, prerelease: false}' \
+            --arg tag_name "$RELEASE_TAG" \
+            '{name: $name, body: $body, tag_name: $tag_name, draft: false, prerelease: false}' \
             > "$RUNNER_TEMP/publish-release.json"
-          gh api --method PATCH \
+          published_json=$(gh api --method PATCH \
             "repos/$GITHUB_REPOSITORY/releases/${{ steps.draft_release.outputs.release_id }}" \
-            --input "$RUNNER_TEMP/publish-release.json" >/dev/null
+            --input "$RUNNER_TEMP/publish-release.json")
+          if ! jq -e --arg tag "$RELEASE_TAG" \
+            '.tag_name == $tag and .draft == false and .prerelease == false' \
+            <<< "$published_json" >/dev/null; then
+            echo "GitHub release publication failed verification" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Publishing the `v0.1.0` Draft GitHub Release without explicitly including its tag in the final update caused the release to become temporarily associated with an `untagged-*` ref.

This change includes the expected release tag in the final publication payload and verifies the tag, draft, and prerelease state after publication.

Maven Central publication and release-note generation are unchanged.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.