### PR TITLE
test: verify VectorStore RAG and stream cancellation boundaries

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -39,6 +39,23 @@ all repository checks with:
 By default, the test suite uses test models and local components. Tests that use
 live remote models or analyzer services are opt-in.
 
+### Privacy Boundary Verification Matrix
+
+The matrix records privacy boundaries verified by reproducible automated tests.
+
+| Boundary | Verified behavior | Test |
+| --- | --- | --- |
+| Direct prompt → model | Raw detected PII is replaced with an opaque request-scoped token before the model call. | [`PrivacyChatClientIntegrationTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyChatClientIntegrationTest.java) |
+| Spring AI chat memory → model copy | Stored memory can retain application-owned raw text while the copy sent to the model is tokenized. | [`PrivacyChatMemoryIntegrationTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyChatMemoryIntegrationTest.java) |
+| Spring AI VectorStore RAG → model | When retrieval returns a document containing detected PII, the raw value is replaced with an opaque token before the model call. | [`PrivacyVectorStoreRagIntegrationTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyVectorStoreRagIntegrationTest.java) |
+| Allowed tool input value disclosure | A scoped tool receives originals only for explicitly allowed entity types. | [`PrivacyToolCallbackWrapperTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapperTest.java) |
+| Denied tool input value disclosure | Raw values of disallowed inputs remain protected. | [`PrivacyToolCallbackWrapperTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapperTest.java) |
+| Tool result → model | Detected PII in tool results is re-tokenized before returning to the model. | [`PrivacySequentialToolIntegrationTest`](../spring-ai-privacy-guardrails-test/src/test/java/io/github/ultramancode/springai/privacy/test/PrivacySequentialToolIntegrationTest.java) |
+| MCP Streamable HTTP tool round trip | The local MCP round trip restores only allowed input values, keeps denied values protected, and re-protects results before they return to the model. | [`McpToolLoopIntegrationTest`](../samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/McpToolLoopIntegrationTest.java) |
+| Request lifecycle on completion and error | Sessions are closed after normal completion and downstream failure. | [`PrivacyLifecycleAdvisorTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyLifecycleAdvisorTest.java) |
+| Logical streaming response protection | Output frames are buffered as one logical response so PII split across frames is protected before delivery to the subscriber. | [`PrivacyOutputAdvisorStreamTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyOutputAdvisorStreamTest.java) |
+| Streaming cancellation after partial response buffering | Cancellation emits no raw PII, cancels upstream processing, closes the privacy session, and invalidates its mapping. | [`PrivacyLifecycleAdvisorTest`](../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyLifecycleAdvisorTest.java) |
+
 ## JMH Benchmarks
 
 The repository's JMH benchmarks measure execution time for key local processing

--- a/docs/ko/evaluation.md
+++ b/docs/ko/evaluation.md
@@ -3,7 +3,7 @@
 [English](../evaluation.md) | [한국어](evaluation.md)
 
 <!-- i18n-source: docs/evaluation.md -->
-<!-- i18n-source-sha256: 09eaf223f366ca324f004152ba349923daf2f3348082a92d83a3244257a095f9 -->
+<!-- i18n-source-sha256: 33949a0ca4fc3dcae1820950db8791d5dd6fc84c408ed6aab2b5591f4d3c3a63 -->
 
 이 저장소에는 데모 분석기의 회귀 테스트, 개인정보 보호 경계 테스트와 JMH 벤치마크가
 포함되어 있습니다. 회귀 테스트는 탐지 결과를, 경계 테스트는 정책 적용을, JMH 벤치마크는
@@ -38,6 +38,23 @@
 
 기본 검증은 테스트용 모델과 로컬 구성 요소를 사용합니다. 실제 원격 모델이나 분석 서비스를
 사용하는 검증은 별도의 선택형 테스트입니다.
+
+### 개인정보 보호 경계 검증 매트릭스
+
+이 매트릭스는 재현 가능한 자동화 테스트로 검증한 개인정보 보호 경계를 기록합니다.
+
+| 경계 | 검증된 동작 | 테스트 |
+| --- | --- | --- |
+| 직접 프롬프트 → 모델 | 탐지된 개인정보 원문은 모델 호출 전에 요청 범위의 불투명 토큰으로 대체됩니다. | [`PrivacyChatClientIntegrationTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyChatClientIntegrationTest.java) |
+| Spring AI 채팅 메모리 → 모델용 복사본 | 저장된 메모리는 애플리케이션 소유 원문을 유지할 수 있지만, 모델에 전달되는 복사본은 토큰화됩니다. | [`PrivacyChatMemoryIntegrationTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyChatMemoryIntegrationTest.java) |
+| Spring AI VectorStore RAG → 모델 | 검색 결과에 탐지된 개인정보가 포함되어 있어도 모델 호출 전 원문은 불투명 토큰으로 대체됩니다. | [`PrivacyVectorStoreRagIntegrationTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyVectorStoreRagIntegrationTest.java) |
+| 허용된 도구 입력값 공개 | 범위가 지정된 도구는 명시적으로 허용된 엔티티 유형의 원문만 받습니다. | [`PrivacyToolCallbackWrapperTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapperTest.java) |
+| 거부된 도구 입력값 공개 | 허용되지 않은 입력값의 원문은 보호 상태를 유지합니다. | [`PrivacyToolCallbackWrapperTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapperTest.java) |
+| 도구 결과 → 모델 | 도구 결과의 탐지된 개인정보는 모델로 돌아가기 전에 다시 토큰화됩니다. | [`PrivacySequentialToolIntegrationTest`](../../spring-ai-privacy-guardrails-test/src/test/java/io/github/ultramancode/springai/privacy/test/PrivacySequentialToolIntegrationTest.java) |
+| MCP Streamable HTTP 도구 왕복 | 로컬 MCP 왕복에서 허용된 입력값만 복원하고, 거부된 값은 보호하며, 결과는 모델로 돌아가기 전에 다시 보호됩니다. | [`McpToolLoopIntegrationTest`](../../samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/McpToolLoopIntegrationTest.java) |
+| 정상 완료와 오류 시 요청 수명주기 | 정상 완료와 downstream 실패 후 세션이 종료됩니다. | [`PrivacyLifecycleAdvisorTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyLifecycleAdvisorTest.java) |
+| 논리적 스트리밍 응답 보호 | 출력 프레임을 하나의 논리적 응답으로 버퍼링하므로 여러 프레임에 걸친 개인정보를 subscriber에게 전달하기 전에 보호합니다. | [`PrivacyOutputAdvisorStreamTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyOutputAdvisorStreamTest.java) |
+| 일부 응답 버퍼링 후 스트리밍 취소 | 취소 시 개인정보 원문을 내보내지 않고 상위 스트림 처리를 취소하며, 개인정보 보호 세션을 종료하고 해당 매핑을 무효화합니다. | [`PrivacyLifecycleAdvisorTest`](../../spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyLifecycleAdvisorTest.java) |
 
 ## JMH 벤치마크
 

--- a/spring-ai-privacy-guardrails-spring-ai/build.gradle
+++ b/spring-ai-privacy-guardrails-spring-ai/build.gradle
@@ -9,5 +9,7 @@ dependencies {
     implementation "tools.jackson.core:jackson-databind:${providers.gradleProperty('jacksonVersion').get()}"
 
     testImplementation 'org.springframework.ai:spring-ai-deepseek'
+    testImplementation 'org.springframework.ai:spring-ai-vector-store'
+    testImplementation 'org.springframework.ai:spring-ai-vector-store-advisor'
     testImplementation "org.mockito:mockito-core:${providers.gradleProperty('mockitoVersion').get()}"
 }

--- a/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyLifecycleAdvisorTest.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyLifecycleAdvisorTest.java
@@ -1,6 +1,7 @@
 package io.github.ultramancode.springai.privacy.springai;
 
 import io.github.ultramancode.springai.privacy.core.OpaquePiiTokenFormat;
+import io.github.ultramancode.springai.privacy.core.PrivacyContextHandle;
 import io.github.ultramancode.springai.privacy.core.PrivacyGuardrailException;
 import io.github.ultramancode.springai.privacy.core.PrivacyService;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -143,6 +146,57 @@ class PrivacyLifecycleAdvisorTest {
         subscription.dispose();
 
         assertThat(service.activeSessionCount()).isZero();
+    }
+
+    @Test
+    void adviseStreamCancellationAfterBufferingRawFrameDoesNotLeakAndDestroysSessionMapping() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        PrivacyLifecycleAdvisor lifecycle = new PrivacyLifecycleAdvisor(service);
+        PrivacyOutputAdvisor output = new PrivacyOutputAdvisor(service);
+        StreamAdvisorChain chain = streamChain(service, lifecycle, output);
+        AtomicBoolean upstreamFrameEmitted = new AtomicBoolean();
+        AtomicBoolean upstreamCancelled = new AtomicBoolean();
+        AtomicReference<PrivacyContextHandle> activeHandle = new AtomicReference<>();
+        AtomicReference<String> sessionToken = new AtomicReference<>();
+        when(chain.nextStream(any())).thenAnswer(invocation -> {
+            ChatClientRequest active = invocation.getArgument(0);
+            PrivacyContextHandle handle = PrivacyRequestContextSupport.findHandle(active).orElseThrow();
+            activeHandle.set(handle);
+            sessionToken.set(service.tokenize(handle, "Alice"));
+            return Flux.concat(
+                            Flux.just(new ChatClientResponse(
+                                            TestPrivacyServices.response("Alice").chatResponse(),
+                                            active.context()
+                                    ))
+                                    .doOnNext(rawResponseFrame -> upstreamFrameEmitted.set(true)),
+                            Flux.never()
+                    )
+                    .doOnCancel(() -> upstreamCancelled.set(true));
+        });
+        List<ChatClientResponse> subscriberResponses = new ArrayList<>();
+
+        reactor.core.Disposable subscription = lifecycle.adviseStream(request(), chain)
+                .subscribe(subscriberResponses::add);
+
+        assertThat(upstreamFrameEmitted).isTrue();
+        assertThat(subscriberResponses).isEmpty();
+        assertThat(sessionToken.get())
+                .matches(OpaquePiiTokenFormat.patternForEntityType("PERSON"));
+        assertThat(service.activeSessionCount()).isOne();
+
+        subscription.dispose();
+
+        assertThat(upstreamCancelled).isTrue();
+        assertThat(subscriberResponses).isEmpty();
+        assertThat(subscriberResponses)
+                .noneSatisfy(response -> assertThat(response.chatResponse()
+                        .getResult()
+                        .getOutput()
+                        .getText()).contains("Alice"));
+        assertThat(service.activeSessionCount()).isZero();
+        assertThatThrownBy(() -> service.detokenize(activeHandle.get(), sessionToken.get()))
+                .isInstanceOf(PrivacyGuardrailException.class)
+                .hasMessageContaining("closed");
     }
 
     @Test

--- a/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyVectorStoreRagIntegrationTest.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyVectorStoreRagIntegrationTest.java
@@ -1,0 +1,134 @@
+package io.github.ultramancode.springai.privacy.springai;
+
+import io.github.ultramancode.springai.privacy.core.OpaquePiiTokenFormat;
+import io.github.ultramancode.springai.privacy.core.PrivacyService;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.ai.vectorstore.VectorStore;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrivacyVectorStoreRagIntegrationTest {
+
+    @Test
+    void localVectorStoreRetrievalIsProtectedBeforeTheModelBoundary() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        VectorStore vectorStore = SimpleVectorStore.builder(new DeterministicEmbeddingModel()).build();
+        vectorStore.add(List.of(
+                new Document("Customer account owner: Alice"),
+                new Document("Weather archive: clear skies")
+        ));
+        RecordingPromptModel model = new RecordingPromptModel();
+        QuestionAnswerAdvisor retrievalAdvisor = QuestionAnswerAdvisor.builder(vectorStore)
+                .searchRequest(SearchRequest.builder()
+                        .topK(1)
+                        .similarityThreshold(0.9)
+                        .build())
+                .build();
+        ChatClient chatClient = ChatClient.builder(model)
+                .defaultAdvisors(
+                        new PrivacyLifecycleAdvisor(service),
+                        new PrivacyInputAdvisor(service),
+                        retrievalAdvisor,
+                        new PrivacyToolContextAdvisor(service),
+                        new PrivacyToolCallValidationAdvisor(service),
+                        new PrivacyModelBoundaryAdvisor(service)
+                )
+                .build();
+
+        ChatClientResponse response = chatClient.prompt()
+                .user("Who owns the customer account?")
+                .call()
+                .chatClientResponse();
+
+        Object retrievedValue = response.context().get(QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS);
+        assertThat(retrievedValue).isInstanceOf(List.class);
+        List<?> retrievedDocuments = (List<?>) retrievedValue;
+        assertThat(retrievedDocuments)
+                .hasSize(1)
+                .allSatisfy(document -> assertThat(document).isInstanceOf(Document.class));
+        assertThat(retrievedDocuments.stream()
+                .map(Document.class::cast)
+                .map(Document::getText))
+                .containsExactly("Customer account owner: Alice");
+        assertThat(model.lastPrompt())
+                .containsPattern(OpaquePiiTokenFormat.patternForEntityType("PERSON"))
+                .doesNotContain("Alice");
+        assertThat(service.activeSessionCount()).isZero();
+    }
+
+    private static final class DeterministicEmbeddingModel implements EmbeddingModel {
+
+        @Override
+        public EmbeddingResponse call(EmbeddingRequest request) {
+            List<Embedding> embeddings = request.getInstructions().stream()
+                    .map(DeterministicEmbeddingModel::vectorFor)
+                    .map(vector -> new Embedding(vector, null))
+                    .toList();
+            return new EmbeddingResponse(embeddings);
+        }
+
+        @Override
+        public float[] embed(Document document) {
+            return vectorFor(document.getText());
+        }
+
+        @Override
+        public int dimensions() {
+            return 2;
+        }
+
+        private static float[] vectorFor(String content) {
+            String normalized = content.toLowerCase(Locale.ROOT);
+            if (normalized.contains("customer") || normalized.contains("account")
+                    || normalized.contains("owner")) {
+                return new float[]{1.0f, 0.0f};
+            }
+            return new float[]{0.0f, 1.0f};
+        }
+    }
+
+    private static final class RecordingPromptModel implements ChatModel {
+
+        private volatile String lastPrompt;
+
+        @Override
+        public ChatResponse call(Prompt prompt) {
+            this.lastPrompt = prompt.getInstructions().stream()
+                    .map(Message::getText)
+                    .filter(Objects::nonNull)
+                    .reduce((left, right) -> left + "\n" + right)
+                    .orElse("");
+            return new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+        }
+
+        @Override
+        public Flux<ChatResponse> stream(Prompt prompt) {
+            return Flux.just(call(prompt));
+        }
+
+        String lastPrompt() {
+            return this.lastPrompt;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Privacy boundary coverage already existed for direct prompts, chat memory, tools, MCP, and request lifecycle, but two focused gaps remained.

The Spring AI RAG path did not exercise an actual VectorStore retrieval, and streaming cancellation was not verified after a raw response frame entered the output buffer.

This change adds a deterministic VectorStore integration test and verifies that retrieved PII is protected before the model boundary.

It also verifies that cancellation exposes no raw PII to the subscriber, cancels upstream processing, closes the privacy session, and makes the closed mapping unusable.

Production code, public APIs, and runtime demo behavior are unchanged.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.
