### PR TITLE
build: reduce Maven Central bundle file count

### DIFF
--- a/build-logic/src/main/java/io/github/ultramancode/privacy/buildlogic/ReleasePlugin.java
+++ b/build-logic/src/main/java/io/github/ultramancode/privacy/buildlogic/ReleasePlugin.java
@@ -157,6 +157,25 @@ public final class ReleasePlugin implements Plugin<Project> {
                 Delete.class,
                 task -> task.delete(project.getLayout().getBuildDirectory().dir("central-staging-repository"))
         );
+        TaskProvider<Delete> pruneCentralChecksums = project.getTasks().register(
+                "pruneCentralStagingRepositoryChecksums",
+                Delete.class,
+                task -> {
+                    task.setGroup("publishing");
+                    task.setDescription(
+                            "Removes checksums that are intentionally omitted from the Central Portal bundle."
+                    );
+                    task.delete(project.fileTree(
+                            project.getLayout().getBuildDirectory().dir("central-staging-repository"),
+                            files -> files.include(
+                                    "**/*.sha256",
+                                    "**/*.sha512",
+                                    "**/*.asc.md5",
+                                    "**/*.asc.sha1"
+                            )
+                    ));
+                }
+        );
         TaskProvider<VerifyCentralStagingRepository> verifyCentral = project.getTasks().register(
                 "verifyCentralStagingRepository",
                 VerifyCentralStagingRepository.class,
@@ -169,6 +188,7 @@ public final class ReleasePlugin implements Plugin<Project> {
                     task.getRepositoryDirectory().set(
                             project.getLayout().getBuildDirectory().dir("central-staging-repository")
                     );
+                    task.dependsOn(pruneCentralChecksums);
                     task.getGroupPath().set(project.getGroup().toString().replace('.', '/'));
                     task.getReleaseVersion().set(project.getProviders().gradleProperty("version"));
                     task.getPublishableProjects().convention(Set.of());
@@ -232,8 +252,8 @@ public final class ReleasePlugin implements Plugin<Project> {
                     task.mustRunAfter(priorCentral);
                 }
             });
+            pruneCentralChecksums.configure(task -> task.dependsOn(centralPublication));
             verifyCentral.configure(task -> {
-                task.dependsOn(centralPublication);
                 task.getPublishableProjects().add(spec.getName());
             });
 

--- a/build-logic/src/main/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyCentralStagingRepository.java
+++ b/build-logic/src/main/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyCentralStagingRepository.java
@@ -9,6 +9,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -40,9 +41,14 @@ public abstract class VerifyCentralStagingRepository extends DefaultTask {
 
     private static final List<String> CHECKSUM_SUFFIXES = List.of(
             ".md5",
-            ".sha1",
+            ".sha1"
+    );
+
+    private static final List<String> FORBIDDEN_CHECKSUM_SUFFIXES = List.of(
             ".sha256",
-            ".sha512"
+            ".sha512",
+            ".asc.md5",
+            ".asc.sha1"
     );
 
     @InputDirectory
@@ -84,7 +90,6 @@ public abstract class VerifyCentralStagingRepository extends DefaultTask {
                 require(repository, artifactPath + ".asc", missing);
                 for (String checksum : CHECKSUM_SUFFIXES) {
                     require(repository, artifactPath + checksum, missing);
-                    require(repository, artifactPath + ".asc" + checksum, missing);
                 }
                 if (artifactSuffix.endsWith(".jar")) {
                     verifyJarLicense(repository, artifactPath, expectedLicense, invalid);
@@ -92,6 +97,9 @@ public abstract class VerifyCentralStagingRepository extends DefaultTask {
             }
             verifyPom(repository, basePath + ".pom", moduleName, version, invalid);
         }
+        invalid.addAll(findForbiddenChecksums(repository).stream()
+                .map(path -> path + " must not be included")
+                .toList());
         if (!missing.isEmpty()) {
             throw new GradleException(
                     "Central Portal bundle is incomplete; missing: " + String.join(", ", missing)
@@ -107,6 +115,22 @@ public abstract class VerifyCentralStagingRepository extends DefaultTask {
                 "Verified complete signed Central staging layout for {} publications.",
                 getPublishableProjects().get().size()
         );
+    }
+
+    static List<String> findForbiddenChecksums(File repository) {
+        Path root = repository.toPath();
+        try (var paths = Files.walk(root)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .map(root::relativize)
+                    .map(path -> path.toString().replace(File.separatorChar, '/'))
+                    .filter(path -> FORBIDDEN_CHECKSUM_SUFFIXES.stream().anyMatch(path::endsWith))
+                    .sorted()
+                    .toList();
+        }
+        catch (IOException ex) {
+            throw new GradleException("Unable to inspect Central staging checksums", ex);
+        }
     }
 
     private static void require(File repository, String relativePath, List<String> missing) {

--- a/build-logic/src/test/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyCentralStagingRepositoryTest.java
+++ b/build-logic/src/test/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyCentralStagingRepositoryTest.java
@@ -1,0 +1,45 @@
+package io.github.ultramancode.privacy.buildlogic.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class VerifyCentralStagingRepositoryTest {
+
+    @TempDir
+    Path repository;
+
+    @Test
+    void rejectsOnlyChecksumsExcludedFromCentralBundles() throws IOException {
+        List<String> retained = List.of(
+                "module-0.1.1.jar",
+                "module-0.1.1.jar.asc",
+                "module-0.1.1.jar.md5",
+                "module-0.1.1.jar.sha1"
+        );
+        List<String> forbidden = List.of(
+                "module-0.1.1.jar.sha256",
+                "module-0.1.1.jar.sha512",
+                "module-0.1.1.jar.asc.md5",
+                "module-0.1.1.jar.asc.sha1",
+                "module-0.1.1.jar.asc.sha256",
+                "module-0.1.1.jar.asc.sha512"
+        );
+        for (String file : retained) {
+            Files.createFile(this.repository.resolve(file));
+        }
+        for (String file : forbidden) {
+            Files.createFile(this.repository.resolve(file));
+        }
+
+        assertThat(VerifyCentralStagingRepository.findForbiddenChecksums(
+                this.repository.toFile()
+        )).containsExactlyElementsOf(forbidden.stream().sorted().toList());
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+# Central Portal bundles retain MD5/SHA-1 compatibility checksums only.
+systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 group=io.github.ultramancode
 version=0.1.0-SNAPSHOT


### PR DESCRIPTION
## Summary

The `v0.1.0` Central Portal bundle contained 400 files because Gradle generated checksums for both publication artifacts and their GPG signatures.

This change keeps only the original artifact, its `.asc` signature, and the original artifact's `.md5` and `.sha1` checksums.
The locally verified bundle now contains 160 files across the existing eight publications.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.
