### PR TITLE
feat: add runtime RAG privacy boundary demo

### DIFF
--- a/samples/spring-ai-demo/README.md
+++ b/samples/spring-ai-demo/README.md
@@ -50,6 +50,18 @@ such as `{"text":"My employee id is EMP-1234"}`. The GET endpoints run the
 checked-in default example; POST requests with missing or blank `text` are
 rejected with HTTP `400` rather than silently substituting that example.
 
+## Local RAG Boundary Demo
+
+```bash
+curl "http://127.0.0.1:8080/demo/rag"
+```
+
+This endpoint retrieves a fixed synthetic document from an in-memory
+`SimpleVectorStore`. The response includes the raw retrieved document and the
+tokenized context actually received by the deterministic local model. This
+confirms that retrieved PII is tokenized before model execution. No external
+vector store, embedding service, or model is used.
+
 ## Regex-Only Protection
 
 ```bash

--- a/samples/spring-ai-demo/build.gradle
+++ b/samples/spring-ai-demo/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     runtimeOnly project(':spring-ai-privacy-guardrails-presidio-spring-boot-starter')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.ai:spring-ai-vector-store'
+    implementation 'org.springframework.ai:spring-ai-vector-store-advisor'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.ai:spring-ai-mcp'
 

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoChatConfiguration.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoChatConfiguration.java
@@ -36,6 +36,11 @@ class PrivacyDemoChatConfiguration {
     }
 
     @Bean
+    PrivacyDemoRag privacyDemoRag(PrivacyChatClientConfigurer privacyConfigurer) {
+        return new PrivacyDemoRag(privacyConfigurer);
+    }
+
+    @Bean
     PrivacyDemoToolLoop privacyDemoToolLoop(
             PrivacyChatClientConfigurer privacyConfigurer,
             PrivacyToolCallbackFactory toolCallbackFactory,

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoController.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoController.java
@@ -24,15 +24,18 @@ public class PrivacyDemoController {
 
     private final PrivacyService privacyService;
     private final ChatClient chatClient;
+    private final PrivacyDemoRag rag;
     private final PrivacyDemoToolLoop toolLoop;
 
     public PrivacyDemoController(
             PrivacyService privacyService,
             ChatClient chatClient,
+            PrivacyDemoRag rag,
             PrivacyDemoToolLoop toolLoop
     ) {
         this.privacyService = privacyService;
         this.chatClient = chatClient;
+        this.rag = rag;
         this.toolLoop = toolLoop;
     }
 
@@ -69,6 +72,19 @@ public class PrivacyDemoController {
                     tokenization.analysis().successfulProviders().stream().sorted().toList()
             );
         }
+    }
+
+    @GetMapping("/rag")
+    public RagResponse rag() {
+        PrivacyDemoRag.Result result = this.rag.run();
+        return new RagResponse(
+                result.retrievedDocument(),
+                result.modelVisibleContext(),
+                result.retrievedDocumentContainsRawPii(),
+                result.modelVisibleContextContainsRawPii(),
+                result.modelVisibleContextContainsTokenizedPii(),
+                this.privacyService.activeSessionCount()
+        );
     }
 
     @GetMapping("/tool-loop")
@@ -113,6 +129,16 @@ public class PrivacyDemoController {
             String protectedPrompt,
             List<DetectedSpan> detectedSpans,
             List<String> successfulProviders
+    ) {
+    }
+
+    public record RagResponse(
+            String retrievedDocument,
+            String modelVisibleContext,
+            boolean retrievedDocumentContainsRawPii,
+            boolean modelVisibleContextContainsRawPii,
+            boolean modelVisibleContextContainsTokenizedPii,
+            int activeSessionsAfterCall
     ) {
     }
 

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoRag.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoRag.java
@@ -1,0 +1,155 @@
+package io.github.ultramancode.springai.privacy.sample;
+
+import io.github.ultramancode.springai.privacy.autoconfigure.PrivacyChatClientConfigurer;
+import io.github.ultramancode.springai.privacy.core.OpaquePiiTokenFormat;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+final class PrivacyDemoRag {
+
+    private static final String QUERY = "Which email owns the customer account?";
+    private static final String RAW_PII = "alice@example.com";
+    private static final String RETRIEVED_DOCUMENT = "Customer account owner email: " + RAW_PII;
+
+    private final ChatClient chatClient;
+    private final RecordingPromptChatModel chatModel;
+
+    PrivacyDemoRag(PrivacyChatClientConfigurer privacyConfigurer) {
+        VectorStore vectorStore = SimpleVectorStore.builder(new DeterministicEmbeddingModel()).build();
+        vectorStore.add(List.of(
+                new Document(RETRIEVED_DOCUMENT),
+                new Document("Weather archive: clear skies")
+        ));
+        QuestionAnswerAdvisor retrievalAdvisor = QuestionAnswerAdvisor.builder(vectorStore)
+                .searchRequest(SearchRequest.builder()
+                        .topK(1)
+                        .similarityThreshold(0.9)
+                        .build())
+                .build();
+        this.chatModel = new RecordingPromptChatModel();
+        ChatClient.Builder builder = ChatClient.builder(this.chatModel)
+                .defaultAdvisors(retrievalAdvisor);
+        this.chatClient = privacyConfigurer.configure(builder).build();
+    }
+
+    Result run() {
+        try {
+            ChatClientResponse response = this.chatClient.prompt()
+                    .user(QUERY)
+                    .call()
+                    .chatClientResponse();
+            String retrievedDocument = requireRetrievedDocument(response);
+            String modelVisibleContext = this.chatModel.requireRecordedPrompt();
+            return new Result(
+                    retrievedDocument,
+                    modelVisibleContext,
+                    retrievedDocument.contains(RAW_PII),
+                    modelVisibleContext.contains(RAW_PII),
+                    OpaquePiiTokenFormat.patternForEntityType("EMAIL_ADDRESS")
+                            .matcher(modelVisibleContext)
+                            .find()
+            );
+        } finally {
+            this.chatModel.clearRecordedPrompt();
+        }
+    }
+
+    private static String requireRetrievedDocument(ChatClientResponse response) {
+        Object value = response.context().get(QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS);
+        if (!(value instanceof List<?> documents)
+                || documents.size() != 1
+                || !(documents.get(0) instanceof Document document)) {
+            throw new IllegalStateException("RAG demo expected exactly one retrieved document");
+        }
+        return document.getText();
+    }
+
+    record Result(
+            String retrievedDocument,
+            String modelVisibleContext,
+            boolean retrievedDocumentContainsRawPii,
+            boolean modelVisibleContextContainsRawPii,
+            boolean modelVisibleContextContainsTokenizedPii
+    ) {
+    }
+
+    private static final class DeterministicEmbeddingModel implements EmbeddingModel {
+
+        @Override
+        public EmbeddingResponse call(EmbeddingRequest request) {
+            List<Embedding> embeddings = request.getInstructions().stream()
+                    .map(DeterministicEmbeddingModel::vectorFor)
+                    .map(vector -> new Embedding(vector, null))
+                    .toList();
+            return new EmbeddingResponse(embeddings);
+        }
+
+        @Override
+        public float[] embed(Document document) {
+            return vectorFor(document.getText());
+        }
+
+        @Override
+        public int dimensions() {
+            return 2;
+        }
+
+        private static float[] vectorFor(String content) {
+            String normalized = content.toLowerCase(Locale.ROOT);
+            if (normalized.contains("customer") || normalized.contains("account")
+                    || normalized.contains("owner")) {
+                return new float[]{1.0f, 0.0f};
+            }
+            return new float[]{0.0f, 1.0f};
+        }
+    }
+
+    private static final class RecordingPromptChatModel implements ChatModel {
+
+        private final ThreadLocal<String> recordedPrompt = new ThreadLocal<>();
+
+        @Override
+        public ChatResponse call(Prompt prompt) {
+            String modelVisibleContext = prompt.getInstructions().stream()
+                    .map(Message::getText)
+                    .filter(Objects::nonNull)
+                    .reduce((left, right) -> left + "\n" + right)
+                    .orElse("");
+            this.recordedPrompt.set(modelVisibleContext);
+            return new ChatResponse(List.of(new Generation(
+                    new AssistantMessage("ok")
+            )));
+        }
+
+        String requireRecordedPrompt() {
+            String prompt = this.recordedPrompt.get();
+            if (prompt == null) {
+                throw new IllegalStateException("RAG demo model did not record a prompt");
+            }
+            return prompt;
+        }
+
+        void clearRecordedPrompt() {
+            this.recordedPrompt.remove();
+        }
+    }
+}

--- a/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoControllerTest.java
+++ b/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoControllerTest.java
@@ -108,6 +108,28 @@ class PrivacyDemoControllerTest {
     }
 
     @Test
+    void ragDemoProtectsRetrievedPiiBeforeTheModelBoundary() throws Exception {
+        this.mockMvc.perform(get("/demo/rag"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.retrievedDocument").value(
+                        "Customer account owner email: alice@example.com"
+                ))
+                .andExpect(jsonPath("$.modelVisibleContext").value(Matchers.containsString(
+                        "Customer account owner email: [[PII_EMAIL_ADDRESS_"
+                )))
+                .andExpect(jsonPath("$.modelVisibleContext").value(Matchers.not(
+                        Matchers.containsString("alice@example.com")
+                )))
+                .andExpect(jsonPath("$.retrievedDocumentContainsRawPii").value(true))
+                .andExpect(jsonPath("$.modelVisibleContextContainsRawPii").value(false))
+                .andExpect(jsonPath("$.modelVisibleContextContainsTokenizedPii").value(true))
+                .andExpect(jsonPath("$.activeSessionsAfterCall").value(0))
+                .andExpect(jsonPath("$.tokenMappings").doesNotExist());
+
+        assertThat(this.privacyService.activeSessionCount()).isZero();
+    }
+
+    @Test
     void protectAcceptsDocumentedEnglishTextWithStructuredIdentifiers() throws Exception {
         this.mockMvc.perform(post("/demo/protect")
                         .contentType("application/json")


### PR DESCRIPTION
## Summary

The RAG privacy boundary is already covered by focused integration tests, but the runnable Spring AI sample did not provide an end-to-end way to inspect the retrieved content and the prompt visible to the model.

This change adds a deterministic `/demo/rag` endpoint backed by an in-memory `SimpleVectorStore` and local embedding and chat models.

The endpoint shows the fixed synthetic retrieved document alongside the tokenized context received by the model, demonstrating that retrieved PII is protected before model execution.

Focused controller coverage verifies that raw PII does not cross the model boundary, tokenized PII is present in the model-visible context, and no privacy session remains after the call.

No external vector store, embedding service, or model is required.

Production library code and public APIs are unchanged.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.