### PR TITLE
feat: add runtime Streamable HTTP MCP privacy demo

### DIFF
--- a/samples/spring-ai-demo/README.md
+++ b/samples/spring-ai-demo/README.md
@@ -130,10 +130,19 @@ Disclosure scope comes from `spring.ai.privacy.tools.disclosures`; the demo uses
 auto-configured `PrivacyToolCallbackFactory` and explicit privacy configurer
 rather than creating parallel policies.
 
-The interactive endpoint uses an in-process CRM delegate so it stays runnable
-without external MCP infrastructure. The sample integration suite also runs the
-flow through a local Streamable HTTP MCP server and checks scoped disclosure and
-result retokenization. MCP is a test-only dependency of this sample.
+The `/demo/tool-loop` endpoint uses an in-process CRM delegate.
+
+## Streamable HTTP MCP Tool Loop Demo
+
+```bash
+curl "http://127.0.0.1:8080/demo/mcp-tool-loop"
+```
+
+This endpoint runs the same deterministic flow through an actual local
+Streamable HTTP MCP round trip. Its evidence shows raw PII absent at the model,
+only `CUSTOMER_ID` restored at the MCP tool, the MCP result protected before
+model re-entry, and zero active privacy sessions after completion. It requires
+no external MCP infrastructure or model.
 
 ## Opt-In OpenAI-Compatible Live Model Verification
 

--- a/samples/spring-ai-demo/build.gradle
+++ b/samples/spring-ai-demo/build.gradle
@@ -21,10 +21,10 @@ dependencies {
     runtimeOnly project(':spring-ai-privacy-guardrails-presidio-spring-boot-starter')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.ai:spring-ai-mcp'
     implementation 'org.springframework.ai:spring-ai-vector-store'
     implementation 'org.springframework.ai:spring-ai-vector-store-advisor'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-    testImplementation 'org.springframework.ai:spring-ai-mcp'
 
     openAiCompatibleLiveTestImplementation 'org.springframework.ai:spring-ai-starter-model-openai'
     openAiCompatibleLiveTestImplementation project(':spring-ai-privacy-guardrails-test')

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/LocalMcpCrmServer.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/LocalMcpCrmServer.java
@@ -11,6 +11,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.Wrapper;
+import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 
 import java.nio.file.Path;
@@ -20,6 +21,7 @@ import java.util.Map;
 
 final class LocalMcpCrmServer implements AutoCloseable {
 
+    private static final String LOOPBACK_ADDRESS = "127.0.0.1";
     private static final String MCP_ENDPOINT = "/mcp";
 
     private final Tomcat tomcat;
@@ -59,6 +61,9 @@ final class LocalMcpCrmServer implements AutoCloseable {
         Tomcat tomcat = new Tomcat();
         tomcat.setPort(0);
         tomcat.setBaseDir(baseDirectory.toString());
+        Connector connector = tomcat.getConnector();
+        connector.setProperty("address", LOOPBACK_ADDRESS);
+        connector.setAsyncTimeout(3_000);
         Context context = tomcat.addContext("", baseDirectory.toString());
         Wrapper wrapper = context.createWrapper();
         wrapper.setName("mcpServlet");
@@ -67,26 +72,35 @@ final class LocalMcpCrmServer implements AutoCloseable {
         wrapper.setAsyncSupported(true);
         context.addChild(wrapper);
         context.addServletMappingDecoded("/*", "mcpServlet");
-        tomcat.getConnector().setAsyncTimeout(3_000);
         try {
             tomcat.start();
         }
-        catch (LifecycleException failure) {
-            mcpServer.close();
-            throw new IllegalStateException("Failed to start the local MCP test server", failure);
+        catch (LifecycleException | RuntimeException | Error failure) {
+            IllegalStateException startupFailure = new IllegalStateException(
+                    "Failed to start the local MCP demo server",
+                    failure
+            );
+            try {
+                mcpServer.closeGracefully();
+            }
+            catch (RuntimeException | Error cleanupFailure) {
+                startupFailure.addSuppressed(cleanupFailure);
+            }
+            cleanupTomcat(tomcat, startupFailure);
+            throw startupFailure;
         }
 
         return new LocalMcpCrmServer(
                 tomcat,
                 mcpServer,
                 lookupHandler,
-                tomcat.getConnector().getLocalPort()
+                connector.getLocalPort()
         );
     }
 
     McpSyncClient connect() {
         HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-                .builder("http://localhost:" + this.port)
+                .builder("http://" + LOOPBACK_ADDRESS + ":" + this.port)
                 .endpoint(MCP_ENDPOINT)
                 .build();
         return McpClient.sync(transport)
@@ -108,17 +122,54 @@ final class LocalMcpCrmServer implements AutoCloseable {
 
     @Override
     public void close() {
+        Throwable cleanupFailure = null;
         try {
             this.mcpServer.closeGracefully();
         }
-        finally {
-            try {
-                this.tomcat.stop();
-                this.tomcat.destroy();
-            }
-            catch (LifecycleException failure) {
-                throw new IllegalStateException("Failed to stop the local MCP test server", failure);
-            }
+        catch (RuntimeException | Error failure) {
+            cleanupFailure = failure;
+        }
+        cleanupFailure = cleanupTomcat(this.tomcat, cleanupFailure);
+        rethrowFailure(cleanupFailure);
+    }
+
+    private static Throwable cleanupTomcat(Tomcat tomcat, Throwable currentFailure) {
+        try {
+            tomcat.stop();
+        }
+        catch (LifecycleException | RuntimeException | Error failure) {
+            currentFailure = appendFailure(
+                    currentFailure,
+                    new IllegalStateException("Failed to stop the local MCP demo server", failure)
+            );
+        }
+
+        try {
+            tomcat.destroy();
+        }
+        catch (LifecycleException | RuntimeException | Error failure) {
+            currentFailure = appendFailure(
+                    currentFailure,
+                    new IllegalStateException("Failed to destroy the local MCP demo server", failure)
+            );
+        }
+        return currentFailure;
+    }
+
+    private static Throwable appendFailure(Throwable current, Throwable additional) {
+        if (current == null) {
+            return additional;
+        }
+        current.addSuppressed(additional);
+        return current;
+    }
+
+    private static void rethrowFailure(Throwable failure) {
+        if (failure instanceof RuntimeException runtimeFailure) {
+            throw runtimeFailure;
+        }
+        if (failure instanceof Error error) {
+            throw error;
         }
     }
 

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoChatConfiguration.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoChatConfiguration.java
@@ -55,6 +55,21 @@ class PrivacyDemoChatConfiguration {
         );
     }
 
+    @Bean(destroyMethod = "close")
+    PrivacyDemoMcpToolLoop privacyDemoMcpToolLoop(
+            PrivacyChatClientConfigurer privacyConfigurer,
+            PrivacyToolCallbackFactory toolCallbackFactory,
+            ToolDisclosurePolicy toolDisclosurePolicy,
+            ObjectMapper objectMapper
+    ) {
+        return new PrivacyDemoMcpToolLoop(
+                privacyConfigurer,
+                toolCallbackFactory,
+                toolDisclosurePolicy,
+                objectMapper
+        );
+    }
+
     private static final class LocalEchoChatModel implements ChatModel {
 
         @Override

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoController.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoController.java
@@ -26,17 +26,20 @@ public class PrivacyDemoController {
     private final ChatClient chatClient;
     private final PrivacyDemoRag rag;
     private final PrivacyDemoToolLoop toolLoop;
+    private final PrivacyDemoMcpToolLoop mcpToolLoop;
 
     public PrivacyDemoController(
             PrivacyService privacyService,
             ChatClient chatClient,
             PrivacyDemoRag rag,
-            PrivacyDemoToolLoop toolLoop
+            PrivacyDemoToolLoop toolLoop,
+            PrivacyDemoMcpToolLoop mcpToolLoop
     ) {
         this.privacyService = privacyService;
         this.chatClient = chatClient;
         this.rag = rag;
         this.toolLoop = toolLoop;
+        this.mcpToolLoop = mcpToolLoop;
     }
 
     @GetMapping("/scenario")
@@ -90,8 +93,21 @@ public class PrivacyDemoController {
     @GetMapping("/tool-loop")
     public ToolLoopResponse toolLoop() {
         PrivacyDemoToolLoop.Result toolLoopResult = this.toolLoop.run(SCENARIO.input());
+        return toolLoopResponse("actual-chat-client-tool-loop", toolLoopResult);
+    }
+
+    @GetMapping("/mcp-tool-loop")
+    public ToolLoopResponse mcpToolLoop() {
+        PrivacyDemoToolLoop.Result toolLoopResult = this.mcpToolLoop.run(SCENARIO.input());
+        return toolLoopResponse("actual-streamable-http-mcp-tool-loop", toolLoopResult);
+    }
+
+    private ToolLoopResponse toolLoopResponse(
+            String mode,
+            PrivacyDemoToolLoop.Result toolLoopResult
+    ) {
         return new ToolLoopResponse(
-                "actual-chat-client-tool-loop",
+                mode,
                 toolLoopResult.modelCalls(),
                 toolLoopResult.modelSawOnlyTokens(),
                 toolLoopResult.protectedModelInput(),

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoMcpToolLoop.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoMcpToolLoop.java
@@ -1,0 +1,294 @@
+package io.github.ultramancode.springai.privacy.sample;
+
+import io.github.ultramancode.springai.privacy.autoconfigure.PrivacyChatClientConfigurer;
+import io.github.ultramancode.springai.privacy.core.OpaquePiiTokenFormat;
+import io.github.ultramancode.springai.privacy.springai.PrivacyToolCallbackFactory;
+import io.github.ultramancode.springai.privacy.springai.ToolDisclosurePolicy;
+import io.github.ultramancode.springai.privacy.springai.ToolDisclosureScope;
+import io.modelcontextprotocol.client.McpSyncClient;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.mcp.McpToolNamePrefixGenerator;
+import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+final class PrivacyDemoMcpToolLoop implements AutoCloseable {
+
+    private static final PrivacyDemoScenario SCENARIO = PrivacyDemoScenario.DEFAULT;
+    private static final List<String> RAW_VALUES = SCENARIO.originalValues();
+    private static final List<String> DENIED_TOOL_VALUES = SCENARIO.deniedToolValues();
+    private static final List<String> ALLOWED_TOOL_VALUES = SCENARIO.allowedToolValues();
+    private static final Pattern EMPLOYEE_ID_TOKEN_PATTERN =
+            OpaquePiiTokenFormat.patternForEntityType("EMPLOYEE_ID");
+    private static final Pattern EMAIL_TOKEN_PATTERN =
+            OpaquePiiTokenFormat.patternForEntityType("EMAIL_ADDRESS");
+    private static final Pattern PHONE_TOKEN_PATTERN =
+            OpaquePiiTokenFormat.patternForEntityType("PHONE_NUMBER");
+    private static final Pattern CUSTOMER_ID_TOKEN_PATTERN =
+            OpaquePiiTokenFormat.patternForEntityType("CUSTOMER_ID");
+    private static final Map<String, String> CRM_RECORDS = Map.of(
+            SCENARIO.customerId(),
+            "CRM result: 직원번호는 %s / 이메일은 %s / 전화번호는 %s / 고객번호는 %s"
+                    .formatted(
+                            SCENARIO.employeeId(),
+                            SCENARIO.email(),
+                            SCENARIO.phone(),
+                            SCENARIO.customerId()
+                    )
+    );
+
+    private final PrivacyChatClientConfigurer privacyConfigurer;
+    private final PrivacyToolCallbackFactory toolCallbackFactory;
+    private final ToolDisclosurePolicy toolDisclosurePolicy;
+    private final ObjectMapper objectMapper;
+    private LocalMcpCrmServer localMcpServer;
+    private McpSyncClient mcpClient;
+    private ToolCallbackProvider protectedMcpTools;
+    private ToolDisclosureScope disclosureScope;
+    private Path serverBaseDirectory;
+
+    PrivacyDemoMcpToolLoop(
+            PrivacyChatClientConfigurer privacyConfigurer,
+            PrivacyToolCallbackFactory toolCallbackFactory,
+            ToolDisclosurePolicy toolDisclosurePolicy,
+            ObjectMapper objectMapper
+    ) {
+        this.privacyConfigurer = privacyConfigurer;
+        this.toolCallbackFactory = toolCallbackFactory;
+        this.toolDisclosurePolicy = toolDisclosurePolicy;
+        this.objectMapper = objectMapper;
+    }
+
+    synchronized PrivacyDemoToolLoop.Result run(String input) {
+        LocalMcpCrmServer server = localMcpServer();
+        initializeMcpClient(server);
+        return runAgainstLocalServer(input, server);
+    }
+
+    @Override
+    public synchronized void close() {
+        LocalMcpCrmServer server = this.localMcpServer;
+        McpSyncClient client = this.mcpClient;
+        Path baseDirectory = this.serverBaseDirectory;
+        this.localMcpServer = null;
+        this.mcpClient = null;
+        this.protectedMcpTools = null;
+        this.disclosureScope = null;
+        this.serverBaseDirectory = null;
+
+        Throwable cleanupFailure = null;
+        if (client != null) {
+            try {
+                if (!client.closeGracefully()) {
+                    cleanupFailure = new IllegalStateException("Failed to close the local MCP demo client");
+                }
+            }
+            catch (RuntimeException | Error failure) {
+                cleanupFailure = failure;
+            }
+        }
+
+        if (server != null) {
+            try {
+                server.close();
+            }
+            catch (RuntimeException | Error failure) {
+                cleanupFailure = appendFailure(cleanupFailure, failure);
+            }
+        }
+
+        if (baseDirectory != null) {
+            try {
+                deleteBaseDirectory(baseDirectory);
+            }
+            catch (RuntimeException | Error failure) {
+                cleanupFailure = appendFailure(cleanupFailure, failure);
+            }
+        }
+
+        rethrowFailure(cleanupFailure);
+    }
+
+    private PrivacyDemoToolLoop.Result runAgainstLocalServer(
+            String input,
+            LocalMcpCrmServer server
+    ) {
+        PrivacyDemoToolLoop.DemoToolLoopModel model =
+                new PrivacyDemoToolLoop.DemoToolLoopModel(this.objectMapper);
+
+        ChatClient.Builder builder = ChatClient.builder(model).defaultTools(this.protectedMcpTools);
+        this.privacyConfigurer.configure(builder);
+
+        int callsBeforeRequest = server.calls();
+        String finalResponse = builder.build().prompt().user(input).call().content();
+        if (server.calls() - callsBeforeRequest != 1) {
+            throw new IllegalStateException("MCP demo expected exactly one tool call");
+        }
+
+        String employeeId = server.receivedArgument("employeeId");
+        String email = server.receivedArgument("email");
+        String phone = server.receivedArgument("phone");
+        String customerId = server.receivedArgument("customerId");
+        String receivedArguments = String.join("\n", employeeId, email, phone, customerId);
+        int deniedRawValueCount = countContainedValues(receivedArguments, DENIED_TOOL_VALUES);
+        int allowedRawValueCount = countContainedValues(receivedArguments, ALLOWED_TOOL_VALUES);
+        boolean receivedOnlyAllowedOriginals = deniedRawValueCount == 0
+                && allowedRawValueCount == ALLOWED_TOOL_VALUES.size()
+                && EMPLOYEE_ID_TOKEN_PATTERN.matcher(employeeId).matches()
+                && EMAIL_TOKEN_PATTERN.matcher(email).matches()
+                && PHONE_TOKEN_PATTERN.matcher(phone).matches()
+                && SCENARIO.customerId().equals(customerId)
+                && !CUSTOMER_ID_TOKEN_PATTERN.matcher(customerId).find();
+
+        return new PrivacyDemoToolLoop.Result(
+                model.calls(),
+                !model.rawPiiSeenByModel(),
+                model.protectedModelInput(),
+                model.issuedToolArguments(),
+                this.disclosureScope.entityTypes().stream().sorted().toList(),
+                receivedOnlyAllowedOriginals,
+                server.lookupSucceeded(),
+                model.protectedToolResultSeenByModel(),
+                new PrivacyDemoToolLoop.BoundaryEvidence(
+                        PrivacyDemoToolLoop.EvidenceCount.expectedNone(
+                                model.rawValueCount(),
+                                RAW_VALUES.size()
+                        ),
+                        PrivacyDemoToolLoop.EvidenceCount.expectedNone(
+                                deniedRawValueCount,
+                                DENIED_TOOL_VALUES.size()
+                        ),
+                        PrivacyDemoToolLoop.EvidenceCount.expectedAll(
+                                allowedRawValueCount,
+                                ALLOWED_TOOL_VALUES.size()
+                        ),
+                        PrivacyDemoToolLoop.EvidenceCount.expectedNone(
+                                model.rawToolResultValueCountAtModel(),
+                                RAW_VALUES.size()
+                        )
+                ),
+                finalResponse
+        );
+    }
+
+    private void initializeMcpClient(LocalMcpCrmServer server) {
+        if (this.mcpClient != null) {
+            return;
+        }
+
+        McpSyncClient client = server.connect();
+        try {
+            client.initialize();
+            ToolCallbackProvider mcpTools = SyncMcpToolCallbackProvider.builder()
+                    .mcpClients(client)
+                    .toolNamePrefixGenerator(McpToolNamePrefixGenerator.noPrefix())
+                    .build();
+            ToolDefinition toolDefinition = requireSingleToolDefinition(mcpTools);
+            ToolDisclosureScope scope = Objects.requireNonNull(
+                    this.toolDisclosurePolicy.scopeFor(toolDefinition),
+                    "tool disclosure policy must return a scope"
+            );
+            ToolCallbackProvider protectedTools = this.toolCallbackFactory.wrapProvider(mcpTools);
+
+            this.mcpClient = client;
+            this.protectedMcpTools = protectedTools;
+            this.disclosureScope = scope;
+        }
+        catch (RuntimeException | Error failure) {
+            try {
+                if (!client.closeGracefully()) {
+                    failure.addSuppressed(new IllegalStateException(
+                            "Failed to close the local MCP demo client after initialization failure"
+                    ));
+                }
+            }
+            catch (RuntimeException | Error cleanupFailure) {
+                failure.addSuppressed(cleanupFailure);
+            }
+            throw failure;
+        }
+    }
+
+    private LocalMcpCrmServer localMcpServer() {
+        if (this.localMcpServer != null) {
+            return this.localMcpServer;
+        }
+
+        Path baseDirectory = createBaseDirectory();
+        try {
+            this.localMcpServer = LocalMcpCrmServer.start(baseDirectory, CRM_RECORDS);
+            this.serverBaseDirectory = baseDirectory;
+            return this.localMcpServer;
+        }
+        catch (RuntimeException | Error failure) {
+            try {
+                deleteBaseDirectory(baseDirectory);
+            }
+            catch (RuntimeException cleanupFailure) {
+                failure.addSuppressed(cleanupFailure);
+            }
+            throw failure;
+        }
+    }
+
+    private static ToolDefinition requireSingleToolDefinition(ToolCallbackProvider toolCallbackProvider) {
+        ToolCallback[] toolCallbacks = toolCallbackProvider.getToolCallbacks();
+        if (toolCallbacks == null || toolCallbacks.length != 1 || toolCallbacks[0] == null) {
+            throw new IllegalStateException("MCP demo expected exactly one tool definition");
+        }
+        return toolCallbacks[0].getToolDefinition();
+    }
+
+    private static int countContainedValues(String text, List<String> values) {
+        return Math.toIntExact(values.stream().filter(text::contains).count());
+    }
+
+    private static Throwable appendFailure(Throwable current, Throwable additional) {
+        if (current == null) {
+            return additional;
+        }
+        current.addSuppressed(additional);
+        return current;
+    }
+
+    private static void rethrowFailure(Throwable failure) {
+        if (failure instanceof RuntimeException runtimeFailure) {
+            throw runtimeFailure;
+        }
+        if (failure instanceof Error error) {
+            throw error;
+        }
+    }
+
+    private static Path createBaseDirectory() {
+        try {
+            return Files.createTempDirectory("privacy-mcp-demo-");
+        }
+        catch (IOException failure) {
+            throw new IllegalStateException("Failed to create the local MCP demo directory", failure);
+        }
+    }
+
+    private static void deleteBaseDirectory(Path baseDirectory) {
+        try (Stream<Path> paths = Files.walk(baseDirectory)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+        catch (IOException failure) {
+            throw new IllegalStateException("Failed to remove the local MCP demo directory", failure);
+        }
+    }
+}

--- a/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoToolLoop.java
+++ b/samples/spring-ai-demo/src/main/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoToolLoop.java
@@ -136,16 +136,16 @@ final class PrivacyDemoToolLoop {
             }
         }
 
-        private static EvidenceCount expectedNone(int observed, int total) {
+        static EvidenceCount expectedNone(int observed, int total) {
             return new EvidenceCount(observed, total, observed == 0);
         }
 
-        private static EvidenceCount expectedAll(int observed, int total) {
+        static EvidenceCount expectedAll(int observed, int total) {
             return new EvidenceCount(observed, total, observed == total);
         }
     }
 
-    private static final class DemoToolLoopModel implements ChatModel {
+    static final class DemoToolLoopModel implements ChatModel {
 
         private final ObjectMapper objectMapper;
         private final Set<String> rawValuesSeenByModel = new LinkedHashSet<>();
@@ -155,7 +155,7 @@ final class PrivacyDemoToolLoop {
         private String protectedModelInput;
         private String issuedToolArguments;
 
-        private DemoToolLoopModel(ObjectMapper objectMapper) {
+        DemoToolLoopModel(ObjectMapper objectMapper) {
             this.objectMapper = objectMapper;
         }
 
@@ -247,31 +247,31 @@ final class PrivacyDemoToolLoop {
             return new ChatResponse(List.of(new Generation(message)));
         }
 
-        private int calls() {
+        int calls() {
             return this.calls;
         }
 
-        private boolean rawPiiSeenByModel() {
+        boolean rawPiiSeenByModel() {
             return !this.rawValuesSeenByModel.isEmpty();
         }
 
-        private int rawValueCount() {
+        int rawValueCount() {
             return this.rawValuesSeenByModel.size();
         }
 
-        private boolean protectedToolResultSeenByModel() {
+        boolean protectedToolResultSeenByModel() {
             return this.protectedToolResultSeenByModel;
         }
 
-        private String issuedToolArguments() {
+        String issuedToolArguments() {
             return this.issuedToolArguments;
         }
 
-        private int rawToolResultValueCountAtModel() {
+        int rawToolResultValueCountAtModel() {
             return this.rawToolResultValueCountAtModel;
         }
 
-        private String protectedModelInput() {
+        String protectedModelInput() {
             return this.protectedModelInput;
         }
     }

--- a/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoControllerTest.java
+++ b/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/PrivacyDemoControllerTest.java
@@ -1,11 +1,14 @@
 package io.github.ultramancode.springai.privacy.sample;
 
 import io.github.ultramancode.springai.privacy.core.PrivacyService;
+import io.modelcontextprotocol.client.McpSyncClient;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +27,9 @@ class PrivacyDemoControllerTest {
 
     @Autowired
     private PrivacyService privacyService;
+
+    @Autowired
+    private PrivacyDemoMcpToolLoop mcpToolLoop;
 
     @Test
     void inspectorIsServedAsASampleOnlyBoundaryVisualization() throws Exception {
@@ -230,5 +236,81 @@ class PrivacyDemoControllerTest {
                         Matchers.containsString("tokenMappings"))));
 
         assertThat(this.privacyService.activeSessionCount()).isZero();
+    }
+
+    @Test
+    @Timeout(20)
+    void repeatedMcpToolLoopCallsReuseRuntimeAndPreservePrivacyEvidence() throws Exception {
+        assertMcpToolLoopEvidence();
+        assertThat(this.privacyService.activeSessionCount()).isZero();
+
+        LocalMcpCrmServer firstServer = (LocalMcpCrmServer) ReflectionTestUtils.getField(
+                this.mcpToolLoop,
+                "localMcpServer"
+        );
+        McpSyncClient firstClient = (McpSyncClient) ReflectionTestUtils.getField(
+                this.mcpToolLoop,
+                "mcpClient"
+        );
+        assertThat(firstServer).isNotNull();
+        assertThat(firstClient).isNotNull();
+        assertThat(firstClient.getCurrentInitializationResult()).isNotNull();
+        int callsAfterFirstRequest = firstServer.calls();
+
+        assertMcpToolLoopEvidence();
+        assertThat(this.privacyService.activeSessionCount()).isZero();
+
+        assertThat(ReflectionTestUtils.getField(this.mcpToolLoop, "localMcpServer"))
+                .isSameAs(firstServer);
+        assertThat(ReflectionTestUtils.getField(this.mcpToolLoop, "mcpClient"))
+                .isSameAs(firstClient);
+        assertThat(firstServer.calls()).isEqualTo(callsAfterFirstRequest + 1);
+    }
+
+    private void assertMcpToolLoopEvidence() throws Exception {
+        this.mockMvc.perform(get("/demo/mcp-tool-loop"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mode").value("actual-streamable-http-mcp-tool-loop"))
+                .andExpect(jsonPath("$.modelCalls").value(2))
+                .andExpect(jsonPath("$.modelSawOnlyTokens").value(true))
+                .andExpect(jsonPath("$.protectedModelInput").value(Matchers.containsString(
+                        "[[PII_EMPLOYEE_ID_"
+                )))
+                .andExpect(jsonPath("$.tokenizedToolArguments").value(Matchers.containsString(
+                        "[[PII_CUSTOMER_ID_"
+                )))
+                .andExpect(jsonPath("$.allowedOriginalEntityTypes[0]").value("CUSTOMER_ID"))
+                .andExpect(jsonPath("$.toolReceivedOnlyAllowedOriginals").value(true))
+                .andExpect(jsonPath("$.toolLookupSucceededWithRestoredCustomerId").value(true))
+                .andExpect(jsonPath("$.toolResultRetokenizedBeforeModel").value(true))
+                .andExpect(jsonPath("$.boundaryEvidence.modelRawValues.observed").value(0))
+                .andExpect(jsonPath("$.boundaryEvidence.modelRawValues.total").value(4))
+                .andExpect(jsonPath("$.boundaryEvidence.modelRawValues.passed").value(true))
+                .andExpect(jsonPath("$.boundaryEvidence.deniedToolRawValues.observed").value(0))
+                .andExpect(jsonPath("$.boundaryEvidence.deniedToolRawValues.total").value(3))
+                .andExpect(jsonPath("$.boundaryEvidence.deniedToolRawValues.passed").value(true))
+                .andExpect(jsonPath("$.boundaryEvidence.allowedToolRawValues.observed").value(1))
+                .andExpect(jsonPath("$.boundaryEvidence.allowedToolRawValues.total").value(1))
+                .andExpect(jsonPath("$.boundaryEvidence.allowedToolRawValues.passed").value(true))
+                .andExpect(jsonPath("$.boundaryEvidence.rawToolResultValuesAtModel.observed").value(0))
+                .andExpect(jsonPath("$.boundaryEvidence.rawToolResultValuesAtModel.total").value(4))
+                .andExpect(jsonPath("$.boundaryEvidence.rawToolResultValuesAtModel.passed").value(true))
+                .andExpect(jsonPath("$.finalResponse").value(Matchers.containsString(
+                        "[[PII_EMPLOYEE_ID_"
+                )))
+                .andExpect(jsonPath("$.activeSessionsAfterCall").value(0))
+                .andExpect(content().string(Matchers.not(Matchers.containsString("EMP-1234"))))
+                .andExpect(content().string(Matchers.not(Matchers.containsString(
+                        "test@example.com"
+                ))))
+                .andExpect(content().string(Matchers.not(Matchers.containsString(
+                        "010-1234-5678"
+                ))))
+                .andExpect(content().string(Matchers.not(Matchers.containsString(
+                        "CUST-123456"
+                ))))
+                .andExpect(content().string(Matchers.not(Matchers.containsString(
+                        "tokenMappings"
+                ))));
     }
 }


### PR DESCRIPTION
## Summary

The existing integration test verifies the Streamable HTTP MCP privacy boundary, but the runnable sample did not expose the same round trip at runtime.

This change adds a deterministic `/demo/mcp-tool-loop` endpoint backed by a loopback MCP server and an application-lifetime MCP client, reusing the existing local server semantics.

The endpoint demonstrates that raw PII does not reach the model, only `CUSTOMER_ID` is restored at the MCP tool boundary, denied entities remain tokenized, and the MCP result is protected before model re-entry.

Focused tests cover repeated calls and lifecycle cleanup.

The demo requires no external MCP infrastructure or model and does not change public APIs.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [X] I updated any affected documentation and configuration examples.