### PR TITLE
chore: publish release notes from changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,51 @@ jobs:
           ./gradlew --no-daemon validateReleaseVersion -Pversion="$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Extract release notes from changelog
+        run: |
+          version="${{ steps.release.outputs.version }}"
+          heading="## [$version]"
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          if ! awk -v heading="$heading" '
+            {
+              line = $0
+              sub(/\r$/, "", line)
+            }
+            line == heading {
+              found = 1
+              in_section = 1
+              next
+            }
+            in_section && line ~ /^## / {
+              exit
+            }
+            !in_section {
+              next
+            }
+            line ~ /^[[:space:]]*$/ {
+              if (has_content) {
+                pending_blank_lines++
+              }
+              next
+            }
+            {
+              while (pending_blank_lines > 0) {
+                print ""
+                pending_blank_lines--
+              }
+              print line
+              has_content = 1
+            }
+            END {
+              if (!found || !has_content) {
+                exit 1
+              }
+            }
+          ' CHANGELOG.md > "$notes_file"; then
+            echo "CHANGELOG.md must contain a non-empty $heading section" >&2
+            exit 1
+          fi
+
       - name: Verify and build signed release bundle
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
@@ -426,14 +471,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          notes_json=$(gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-            -f tag_name="$RELEASE_TAG")
-          release_name=$(jq -r .name <<< "$notes_json")
-          release_body=$(jq -r .body <<< "$notes_json")
           jq -n \
-            --arg name "$release_name" \
-            --arg body "$release_body" \
+            --arg name "$RELEASE_TAG" \
+            --rawfile body "$RUNNER_TEMP/release-notes.md" \
             --arg tag_name "$RELEASE_TAG" \
             '{name: $name, body: $body, tag_name: $tag_name, draft: false, prerelease: false}' \
             > "$RUNNER_TEMP/publish-release.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.1.1]
+
+This release adds runnable privacy-boundary demos and expands integration-test
+coverage.
+
+### Added
+
+- Added runnable RAG and Streamable HTTP MCP demos that show privacy boundaries
+  at runtime.
+- Added an English and Korean Privacy Boundary Inspector covering Local Tool,
+  RAG, and MCP scenarios.
+- Expanded integration-test coverage for PII protection in VectorStore RAG
+  flows and cleanup after stream cancellation.
+- Added English and Korean sample guides and refreshed Inspector demo GIFs.
+
+### Compatibility
+
+- Public APIs and runtime behavior of the published library modules remain
+  unchanged.
+- No breaking changes.
+
 ## [0.1.0]
 
 Initial public release.


### PR DESCRIPTION
## Summary

GitHub Releases currently generate notes independently of `CHANGELOG.md`.

This change adds the `v0.1.1` release notes to `CHANGELOG.md` and updates the release workflow to use the section matching the validated tag version as the final GitHub Release body.

The workflow fails before Maven Central publication when the matching section is missing or empty.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.
