### PR TITLE
fix: tune Maven Central release polling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     name: Publish ${{ github.ref_name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 90
     environment: maven-central
     env:
       RELEASE_TAG: ${{ github.ref_name }}
@@ -329,11 +329,17 @@ jobs:
           echo "::add-mask::$authorization"
           deployment_id="${{ steps.central.outputs.deployment_id }}"
           state=
-          for _ in $(seq 1 90); do
+          validation_started_at=$SECONDS
+          validation_deadline=$((validation_started_at + 1800))
+          attempt=0
+          while (( SECONDS < validation_deadline )); do
+            attempt=$((attempt + 1))
             status_json=$(curl --request POST --fail-with-body --silent --show-error \
               --header "Authorization: Bearer $authorization" \
               "https://central.sonatype.com/api/v1/publisher/status?id=$deployment_id")
             state=$(jq -r '.deploymentState // empty' <<< "$status_json")
+            elapsed=$((SECONDS - validation_started_at))
+            echo "Maven Central validation state=$state; attempt=$attempt; elapsed=${elapsed}s"
             case "$state" in
               VALIDATED|PUBLISHING|PUBLISHED)
                 break
@@ -352,7 +358,7 @@ jobs:
             esac
           done
           if [[ "$state" != "VALIDATED" && "$state" != "PUBLISHING" && "$state" != "PUBLISHED" ]]; then
-            echo "Maven Central validation timed out in state $state" >&2
+            echo "Maven Central validation timed out after 30 minutes in state $state" >&2
             exit 1
           fi
           echo "state=$state" >> "$GITHUB_OUTPUT"
@@ -394,11 +400,17 @@ jobs:
           deployment_id="${{ steps.central.outputs.deployment_id }}"
           state=
           status_json=
-          for _ in $(seq 1 90); do
+          publication_started_at=$SECONDS
+          publication_deadline=$((publication_started_at + 1800))
+          attempt=0
+          while (( SECONDS < publication_deadline )); do
+            attempt=$((attempt + 1))
             status_json=$(curl --request POST --fail-with-body --silent --show-error \
               --header "Authorization: Bearer $authorization" \
               "https://central.sonatype.com/api/v1/publisher/status?id=$deployment_id")
             state=$(jq -r '.deploymentState // empty' <<< "$status_json")
+            elapsed=$((SECONDS - publication_started_at))
+            echo "Maven Central publication state=$state; attempt=$attempt; elapsed=${elapsed}s"
             case "$state" in
               PUBLISHED)
                 break
@@ -407,7 +419,10 @@ jobs:
                 jq -c '.errors // []' <<< "$status_json" >&2
                 exit 1
                 ;;
-              PENDING|VALIDATING|VALIDATED|PUBLISHING)
+              PUBLISHING)
+                sleep 60
+                ;;
+              PENDING|VALIDATING|VALIDATED)
                 sleep 10
                 ;;
               *)
@@ -417,9 +432,12 @@ jobs:
             esac
           done
           if [[ "$state" != "PUBLISHED" ]]; then
-            echo "Maven Central publication timed out in state $state" >&2
+            echo "Maven Central publication timed out after 30 minutes in state $state" >&2
             exit 1
           fi
+
+      - name: Verify all modules on public Maven Central
+        run: |
           modules=(
             spring-ai-privacy-guardrails-core
             spring-ai-privacy-guardrails-opennlp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,18 @@
 
 ## [0.1.1]
 
-This release adds runnable privacy-boundary demos and expands integration-test
-coverage.
+This release adds runnable privacy-boundary demos and expands integration-test coverage.
 
 ### Added
 
-- Added runnable RAG and Streamable HTTP MCP demos that show privacy boundaries
-  at runtime.
-- Added an English and Korean Privacy Boundary Inspector covering Local Tool,
-  RAG, and MCP scenarios.
-- Expanded integration-test coverage for PII protection in VectorStore RAG
-  flows and cleanup after stream cancellation.
+- Added runnable RAG and Streamable HTTP MCP demos that show privacy boundaries at runtime.
+- Added an English and Korean Privacy Boundary Inspector covering Local Tool, RAG, and MCP scenarios.
+- Expanded integration-test coverage for PII protection in VectorStore RAG flows and cleanup after stream cancellation.
 - Added English and Korean sample guides and refreshed Inspector demo GIFs.
 
 ### Compatibility
 
-- Public APIs and runtime behavior of the published library modules remain
-  unchanged.
+- Public APIs and runtime behavior of the published library modules remain unchanged.
 - No breaking changes.
 
 ## [0.1.0]

--- a/build-logic/src/main/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyReleaseWorkflowContract.java
+++ b/build-logic/src/main/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyReleaseWorkflowContract.java
@@ -21,6 +21,14 @@ public abstract class VerifyReleaseWorkflowContract extends DefaultTask {
             "\"https://central.sonatype.com/api/v1/publisher/upload?";
     private static final String RECOVERY_MARKER =
             "recovery_marker=\"<!-- central-deployment-id:";
+    private static final String CENTRAL_PUBLICATION_STEP =
+            "- name: Wait for Maven Central publication";
+    private static final String PUBLIC_MODULE_VERIFICATION_STEP =
+            "- name: Verify all modules on public Maven Central";
+    private static final String PUBLIC_CONSUMER_STEP =
+            "- name: Run consumer from public Maven Central";
+    private static final String GITHUB_RELEASE_STEP =
+            "- name: Publish GitHub release";
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -34,7 +42,7 @@ public abstract class VerifyReleaseWorkflowContract extends DefaultTask {
         );
         verify(workflow);
         getLogger().lifecycle(
-                "Verified release evidence ordering and Maven-POM-only consumer preflight."
+                "Verified release evidence and public consumer ordering."
         );
     }
 
@@ -51,6 +59,35 @@ public abstract class VerifyReleaseWorkflowContract extends DefaultTask {
         if (!workflow.contains("publishedPomOnlyArtifactSmokeTest")) {
             throw new GradleException(
                     "Release workflow must execute publishedPomOnlyArtifactSmokeTest"
+            );
+        }
+
+        int centralPublication = uniqueIndex(
+                workflow,
+                CENTRAL_PUBLICATION_STEP,
+                "Maven Central publication wait step"
+        );
+        int publicModuleVerification = uniqueIndex(
+                workflow,
+                PUBLIC_MODULE_VERIFICATION_STEP,
+                "public Maven Central module verification step"
+        );
+        int publicConsumer = uniqueIndex(
+                workflow,
+                PUBLIC_CONSUMER_STEP,
+                "public Maven Central consumer step"
+        );
+        int githubRelease = uniqueIndex(
+                workflow,
+                GITHUB_RELEASE_STEP,
+                "GitHub Release publication step"
+        );
+        if (centralPublication >= publicModuleVerification
+                || publicModuleVerification >= publicConsumer
+                || publicConsumer >= githubRelease) {
+            throw new GradleException(
+                    "Release workflow must wait for Central publication, verify every public "
+                            + "module, run the public consumer, and only then publish GitHub Release"
             );
         }
     }

--- a/build-logic/src/test/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyReleaseWorkflowContractTest.java
+++ b/build-logic/src/test/java/io/github/ultramancode/privacy/buildlogic/tasks/VerifyReleaseWorkflowContractTest.java
@@ -9,13 +9,8 @@ import org.junit.jupiter.api.Test;
 class VerifyReleaseWorkflowContractTest {
 
     @Test
-    void acceptsDurableEvidenceBeforeCentralAndMarkerPersistence() {
-        String workflow = """
-                publishedPomOnlyArtifactSmokeTest
-                gh release upload "$RELEASE_TAG"
-                "https://central.sonatype.com/api/v1/publisher/upload?
-                recovery_marker="<!-- central-deployment-id:
-                """;
+    void acceptsDurableEvidenceAndPublicReleaseOrdering() {
+        String workflow = validWorkflow();
 
         assertThatCode(() -> VerifyReleaseWorkflowContract.verify(workflow))
                 .doesNotThrowAnyException();
@@ -23,12 +18,14 @@ class VerifyReleaseWorkflowContractTest {
 
     @Test
     void rejectsMarkerThatCanExistBeforeDraftEvidence() {
-        String workflow = """
-                publishedPomOnlyArtifactSmokeTest
-                "https://central.sonatype.com/api/v1/publisher/upload?
-                recovery_marker="<!-- central-deployment-id:
-                gh release upload "$RELEASE_TAG"
-                """;
+        String workflow = validWorkflow().replace(
+                "gh release upload \"$RELEASE_TAG\"\n"
+                        + "\"https://central.sonatype.com/api/v1/publisher/upload?\n"
+                        + "recovery_marker=\"<!-- central-deployment-id:",
+                "\"https://central.sonatype.com/api/v1/publisher/upload?\n"
+                        + "recovery_marker=\"<!-- central-deployment-id:\n"
+                        + "gh release upload \"$RELEASE_TAG\""
+        );
 
         assertThatThrownBy(() -> VerifyReleaseWorkflowContract.verify(workflow))
                 .isInstanceOf(GradleException.class)
@@ -37,14 +34,37 @@ class VerifyReleaseWorkflowContractTest {
 
     @Test
     void rejectsWorkflowThatOmitsPomOnlyConsumerPreflight() {
-        String workflow = """
-                gh release upload "$RELEASE_TAG"
-                "https://central.sonatype.com/api/v1/publisher/upload?
-                recovery_marker="<!-- central-deployment-id:
-                """;
+        String workflow = validWorkflow().replace("publishedPomOnlyArtifactSmokeTest\n", "");
 
         assertThatThrownBy(() -> VerifyReleaseWorkflowContract.verify(workflow))
                 .isInstanceOf(GradleException.class)
                 .hasMessageContaining("publishedPomOnlyArtifactSmokeTest");
+    }
+
+    @Test
+    void rejectsGitHubReleaseBeforePublicArtifactVerification() {
+        String withoutRelease = validWorkflow().replace("- name: Publish GitHub release\n", "");
+        String workflow = withoutRelease.replace(
+                "- name: Verify all modules on public Maven Central",
+                "- name: Publish GitHub release\n"
+                        + "- name: Verify all modules on public Maven Central"
+        );
+
+        assertThatThrownBy(() -> VerifyReleaseWorkflowContract.verify(workflow))
+                .isInstanceOf(GradleException.class)
+                .hasMessageContaining("only then publish GitHub Release");
+    }
+
+    private static String validWorkflow() {
+        return """
+                publishedPomOnlyArtifactSmokeTest
+                gh release upload "$RELEASE_TAG"
+                "https://central.sonatype.com/api/v1/publisher/upload?
+                recovery_marker="<!-- central-deployment-id:
+                - name: Wait for Maven Central publication
+                - name: Verify all modules on public Maven Central
+                - name: Run consumer from public Maven Central
+                - name: Publish GitHub release
+                """;
     }
 }


### PR DESCRIPTION
## Summary

Maven Central can remain in the `PUBLISHING` state close to the existing polling limit.

This change adds explicit 30-minute deadlines for validation and publication, reduces polling frequency while publishing, and logs elapsed time for each status check.

It also separates public module verification into its own step and extends the release workflow contract to preserve publication ordering.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.