### PR TITLE
build: lower the Java baseline to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [21, 25]
+        java: [17, 21, 25]
 
     steps:
       - name: Check out repository
@@ -35,14 +35,20 @@ jobs:
       - name: Build and test
         run: ./gradlew --no-daemon clean check -PtestJavaVersion=${{ matrix.java }}
 
+      - name: Verify published artifact smoke on Java 17 baseline
+        if: matrix.java == 17
+        run: >-
+          ./gradlew --no-daemon
+          publishedArtifactSmokeTest
+          publishedPomOnlyArtifactSmokeTest
+          -PtestJavaVersion=17
+
       - name: Verify Javadoc and publication metadata
         if: matrix.java == 21
         run: >-
           ./gradlew --no-daemon
           javadoc
           generatePomFileForMavenJavaPublication
-          publishedArtifactSmokeTest
-          publishedPomOnlyArtifactSmokeTest
           -PtestJavaVersion=21
 
       - name: Smoke-test repository benchmarks
@@ -114,6 +120,7 @@ jobs:
             :spring-ai-privacy-guardrails-presidio:test \
             :spring-ai-privacy-guardrails-sample-demo:test \
             --tests '*Presidio*LiveIntegrationTest' \
+            -PtestJavaVersion=21 \
             --rerun-tasks
 
       - name: Show Presidio logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
           check_runs=$(gh api \
             "repos/$GITHUB_REPOSITORY/commits/$release_commit/check-runs?per_page=100")
-          required_checks=("Java 21" "Java 25" "Presidio Docker smoke test")
+          required_checks=("Java 17" "Java 21" "Java 25" "Presidio Docker smoke test")
           for check_name in "${required_checks[@]}"; do
             if ! jq -e --arg name "$check_name" \
               '[.check_runs[] | select(.name == $name and .conclusion == "success")] | length > 0' \
@@ -68,7 +68,9 @@ jobs:
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: |
+            17
+            21
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
@@ -136,6 +138,7 @@ jobs:
           publishedPomOnlyArtifactSmokeTest
           cyclonedxBom
           centralPortalBundle
+          -PtestJavaVersion=21
           -Pversion=${{ steps.release.outputs.version }}
 
       - name: Verify release evidence

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,14 @@ The project is pre-1.0. Its contribution flow is:
 ./gradlew clean check
 ```
 
-Java 21 is the baseline, and CI also tests Java 25. New behavior must include
+Java 17 is the baseline, and CI also tests Java 21 and 25. New behavior must include
 focused tests; changes to Spring AI boundaries should include an integration
 test where practical. `check` runs the test suite and verifies the repository's
 module rules. Update the declared module policy when a change intentionally
 alters that graph.
+
+To reproduce another compatibility lane locally, install that JDK and override
+the build/test toolchain, for example with `-PtestJavaVersion=21`.
 
 Name JUnit test methods in `lowerCamelCase` without underscores.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [English](README.md) | [한국어](README.ko.md) | [Documentation](https://ultramancode.github.io/spring-ai-privacy-guardrails/)
 
 <!-- i18n-source: README.md -->
-<!-- i18n-source-sha256: b78c83758b3437d681dd74423bae09bf4f3e65e93b7c3040a38bc4df34ddbe81 -->
+<!-- i18n-source-sha256: 25de59e5a884e237304c5cb524eeab828b459f4db48eeba8e02a9e45d4530095 -->
 
 <p align="center">
   <img src="docs/images/hero.svg" alt="Spring AI Privacy Guardrails 실행 경계" width="100%">
@@ -129,7 +129,7 @@ spring:
         enabled: true
         rules:
           - entity-type: EMPLOYEE_ID
-            pattern: "\\bEMP-\\d{4}\\b"
+            pattern: "(?<![A-Za-z0-9_])EMP-[0-9]{4}(?![A-Za-z0-9_])"
             score: 0.90
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [English](README.md) | [한국어](README.ko.md) | [Documentation](https://ultramancode.github.io/spring-ai-privacy-guardrails/)
 
 <!-- i18n-source: README.md -->
-<!-- i18n-source-sha256: b671c8e5a9df168b041f5317eca73db71ab0e65575a7e484e5fc6b43f63eaa0f -->
+<!-- i18n-source-sha256: b78c83758b3437d681dd74423bae09bf4f3e65e93b7c3040a38bc4df34ddbe81 -->
 
 <p align="center">
   <img src="docs/images/hero.svg" alt="Spring AI Privacy Guardrails 실행 경계" width="100%">
@@ -50,7 +50,7 @@ flowchart LR
 ## 샘플 실행
 
 샘플에는 같은 입력에 항상 같은 결과를 반환하는 로컬 `ChatModel`이 포함되어 있어
-클라우드 자격 증명이 필요하지 않습니다. JDK 21이 설치된 환경에서 저장소 루트의 다음
+클라우드 자격 증명이 필요하지 않습니다. JDK 17이 설치된 환경에서 저장소 루트의 다음
 명령을 실행하세요.
 
 ```bash
@@ -236,14 +236,14 @@ JMH 벤치마크는 라이브러리로 배포되지 않으며, 측정 대상과 
 
 | 구성 요소 | 검증한 버전 |
 | --- | --- |
-| Java 기준 버전 | 21 |
-| Java 호환성 CI | 25 |
+| Java 기준 버전 | 17 |
+| Java 호환성 CI | 17, 21, 25 |
 | Spring AI | 2.0.0 |
 | Spring Boot | 4.1.0 |
 | Gradle wrapper | 9.6.1 |
 
-CI는 Java 21과 25에서 기본 검증을 실행하고, Java 21에서 Presidio 서비스와의 실제 연동
-테스트와 JMH 스모크 테스트를 별도로 실행합니다.
+CI는 Java 17, 21, 25에서 기본 검증을 실행하고, Java 21에서 Presidio 서비스와의 실제
+연동 테스트와 JMH 스모크 테스트를 별도로 실행합니다.
 
 ## 상세 문서
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ flowchart LR
 ## Run the Sample
 
 The sample includes a deterministic local `ChatModel`, so no cloud credentials
-are required. With JDK 21 installed, run the following command from the
+are required. With JDK 17 installed, run the following command from the
 repository root:
 
 ```bash
@@ -247,14 +247,15 @@ in [Evaluation](docs/evaluation.md#jmh-benchmarks).
 
 | Component | Verified version |
 | --- | --- |
-| Java baseline | 21 |
-| Java compatibility CI | 25 |
+| Java baseline | 17 |
+| Java compatibility CI | 17, 21, 25 |
 | Spring AI | 2.0.0 |
 | Spring Boot | 4.1.0 |
 | Gradle wrapper | 9.6.1 |
 
-CI runs the default verification on Java 21 and 25. On Java 21, it separately
-runs live integration tests against a Presidio service and the JMH smoke tests.
+CI runs the default verification on Java 17, 21, and 25. On Java 21, it
+separately runs live integration tests against a Presidio service and the JMH
+smoke tests.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ spring:
         enabled: true
         rules:
           - entity-type: EMPLOYEE_ID
-            pattern: "\\bEMP-\\d{4}\\b"
+            pattern: "(?<![A-Za-z0-9_])EMP-[0-9]{4}(?![A-Za-z0-9_])"
             score: 0.90
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,7 +216,7 @@ spring:
         enabled: true
         rules:
           - entity-type: EMPLOYEE_ID
-            pattern: "\\bEMP-\\d{4}\\b"
+            pattern: "(?<![A-Za-z0-9_])EMP-[0-9]{4}(?![A-Za-z0-9_])"
             score: 0.90
 ```
 
@@ -300,7 +300,7 @@ spring:
         enabled: true
         rules:
           - entity-type: CUSTOMER_ID
-            pattern: "\\bCUST-\\d{6}\\b"
+            pattern: "(?<![A-Za-z0-9_])CUST-[0-9]{6}(?![A-Za-z0-9_])"
             score: 0.90
             capture-group: 0
             validator-id: customer-id-check

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ the [Sample / Demo Guide](sample.md).
 
 The current release is verified with:
 
-- Java 21
+- Java 17
 - Spring AI 2.0.0
 - Spring Boot 4.1.0
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,10 +75,10 @@ spring:
         enabled: true
         rules:
           - entity-type: EMPLOYEE_ID
-            pattern: "\\bEMP-\\d{4}\\b"
+            pattern: "(?<![A-Za-z0-9_])EMP-[0-9]{4}(?![A-Za-z0-9_])"
             score: 0.90
           - entity-type: CUSTOMER_ID
-            pattern: "\\bCUST-\\d{6}\\b"
+            pattern: "(?<![A-Za-z0-9_])CUST-[0-9]{6}(?![A-Za-z0-9_])"
             score: 0.90
 ```
 
@@ -103,7 +103,7 @@ spring:
         enabled: true
         rules:
           - entity-type: CUSTOMER_ID
-            pattern: "\\bCUST-\\d{6}\\b"
+            pattern: "(?<![A-Za-z0-9_])CUST-[0-9]{6}(?![A-Za-z0-9_])"
             score: 0.90
             capture-group: 0
             validator-id: customer-id-check

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -3,7 +3,7 @@
 [English](../configuration.md) | [한국어](configuration.md)
 
 <!-- i18n-source: docs/configuration.md -->
-<!-- i18n-source-sha256: 977c098c071ed742a93b06b8dc2ef0fa3667f034fdc02ae3ca949caf90e8cfba -->
+<!-- i18n-source-sha256: 195674133ab92586897fa4941ad8e2c9ea8d7b09163f168a7efc62120cbddcf3 -->
 
 이 문서는 Spring AI Privacy Guardrails를 사용하는 애플리케이션을 위한 종합
 참고 문서입니다. 기본 Spring Boot 스타터는 `core` 모듈과 Spring AI 통합 경계를
@@ -209,7 +209,7 @@ spring:
         enabled: true
         rules:
           - entity-type: EMPLOYEE_ID
-            pattern: "\\bEMP-\\d{4}\\b"
+            pattern: "(?<![A-Za-z0-9_])EMP-[0-9]{4}(?![A-Za-z0-9_])"
             score: 0.90
 ```
 
@@ -287,7 +287,7 @@ spring:
         enabled: true
         rules:
           - entity-type: CUSTOMER_ID
-            pattern: "\\bCUST-\\d{6}\\b"
+            pattern: "(?<![A-Za-z0-9_])CUST-[0-9]{6}(?![A-Za-z0-9_])"
             score: 0.90
             capture-group: 0
             validator-id: customer-id-check

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -3,7 +3,7 @@
 [English](../getting-started.md) | [한국어](getting-started.md)
 
 <!-- i18n-source: docs/getting-started.md -->
-<!-- i18n-source-sha256: 446be668814a1a7e4fadfed228e8e696940ba5b440df237fed9f605a2205e5b4 -->
+<!-- i18n-source-sha256: 74ec755369d25288a429d77fc1619820b62fc988adaba189ee7025b712392df5 -->
 
 이 가이드는 기존 Spring AI 애플리케이션에 Spring AI Privacy Guardrails를
 추가해 모델, 도구, MCP 및 출력 경계에 개인정보 보호를 적용하는 기본 사용 방법을
@@ -79,10 +79,10 @@ spring:
         enabled: true
         rules:
           - entity-type: EMPLOYEE_ID
-            pattern: "\\bEMP-\\d{4}\\b"
+            pattern: "(?<![A-Za-z0-9_])EMP-[0-9]{4}(?![A-Za-z0-9_])"
             score: 0.90
           - entity-type: CUSTOMER_ID
-            pattern: "\\bCUST-\\d{6}\\b"
+            pattern: "(?<![A-Za-z0-9_])CUST-[0-9]{6}(?![A-Za-z0-9_])"
             score: 0.90
 ```
 
@@ -106,7 +106,7 @@ spring:
         enabled: true
         rules:
           - entity-type: CUSTOMER_ID
-            pattern: "\\bCUST-\\d{6}\\b"
+            pattern: "(?<![A-Za-z0-9_])CUST-[0-9]{6}(?![A-Za-z0-9_])"
             score: 0.90
             capture-group: 0
             validator-id: customer-id-check

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -3,7 +3,7 @@
 [English](../getting-started.md) | [한국어](getting-started.md)
 
 <!-- i18n-source: docs/getting-started.md -->
-<!-- i18n-source-sha256: a1a86cd4ae38e6b1b513c92d85972e659cf9ebf521b5095cc26840d7f503068d -->
+<!-- i18n-source-sha256: 446be668814a1a7e4fadfed228e8e696940ba5b440df237fed9f605a2205e5b4 -->
 
 이 가이드는 기존 Spring AI 애플리케이션에 Spring AI Privacy Guardrails를
 추가해 모델, 도구, MCP 및 출력 경계에 개인정보 보호를 적용하는 기본 사용 방법을
@@ -25,7 +25,7 @@ JVM 내부에서 자체 NER 모델을 사용하려면 OpenNLP를, 애플리케�
 
 현재 릴리즈는 다음 환경에서 검증됩니다.
 
-- Java 21
+- Java 17
 - Spring AI 2.0.0
 - Spring Boot 4.1.0
 

--- a/docs/ko/sample.md
+++ b/docs/ko/sample.md
@@ -3,7 +3,7 @@
 [English](../sample.md) | [한국어](sample.md)
 
 <!-- i18n-source: docs/sample.md -->
-<!-- i18n-source-sha256: c5f493d88183ccf1321a85ba8c5bde4fe21fa59bbcc9c87228d234c30f0a37e7 -->
+<!-- i18n-source-sha256: 930961a32c7cfe45a9c11352923b75b776bf7993dd3217010833417b35fea5e0 -->
 
 실행 가능한 샘플은 항상 같은 결과를 반환하는 로컬 `ChatModel`, 메모리 내 RAG 구성 요소,
 루프백 MCP 서버를 사용하므로 클라우드 자격 증명이 필요하지 않습니다. **Privacy
@@ -13,7 +13,7 @@ Boundary Inspector**는 샘플 백엔드가 반환한 런타임 근거를 표시
 
 ## Inspector 실행
 
-JDK 21이 설치된 환경에서 저장소 루트의 다음 명령을 실행합니다.
+JDK 17이 설치된 환경에서 저장소 루트의 다음 명령을 실행합니다.
 
 ```bash
 ./gradlew :spring-ai-privacy-guardrails-sample-demo:run

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -11,7 +11,7 @@ returned by the sample backend.
 
 ## Run the Inspector
 
-From the repository root, with JDK 21 installed:
+From the repository root, with JDK 17 installed:
 
 ```bash
 ./gradlew :spring-ai-privacy-guardrails-sample-demo:run

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,9 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 group=io.github.ultramancode
 version=0.1.0-SNAPSHOT
 
-javaVersion=21
+# javaVersion defines the source/bytecode baseline and default Java toolchain.
+# testJavaVersion optionally overrides the Java toolchain used for compatibility testing.
+javaVersion=17
 springBootVersion=4.1.0
 springAiVersion=2.0.0
 openNlpVersion=2.5.10

--- a/samples/published-artifact-consumer/build.gradle
+++ b/samples/published-artifact-consumer/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/samples/published-artifact-consumer/src/main/java/example/PublishedArtifactConsumer.java
+++ b/samples/published-artifact-consumer/src/main/java/example/PublishedArtifactConsumer.java
@@ -100,7 +100,7 @@ public class PublishedArtifactConsumer {
             if (probe.modelRequests().size() != 2 || probe.toolCalls().size() != 1) {
                 throw new IllegalStateException("Published configurer did not execute one complete tool loop");
             }
-            ToolCallSnapshot call = probe.toolCalls().getFirst();
+            ToolCallSnapshot call = probe.toolCalls().get(0);
             if (!call.input().contains("CUST-0042") || call.input().contains("alice@example.com")) {
                 throw new IllegalStateException("Published tool wrapper violated scoped disclosure");
             }

--- a/samples/spring-ai-demo/src/main/resources/application.yml
+++ b/samples/spring-ai-demo/src/main/resources/application.yml
@@ -20,21 +20,23 @@ spring:
             - CUSTOMER_ID
       regex:
         enabled: true
+        # Prefer explicit ASCII boundaries to \b for ASCII-oriented rules,
+        # so behavior stays consistent across supported JDKs.
         rules:
           - entity-type: EMAIL_ADDRESS
-            pattern: '\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b'
+            pattern: '(?<![A-Za-z0-9_])(?=[A-Za-z0-9_])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9_])'
             score: 0.95
           - entity-type: PHONE_NUMBER
-            pattern: '\b01[016789]-\d{3,4}-\d{4}\b'
+            pattern: '(?<![A-Za-z0-9_])01[016789]-[0-9]{3,4}-[0-9]{4}(?![A-Za-z0-9_])'
             score: 0.95
           - entity-type: KOREAN_RRN
-            pattern: '\b\d{6}-[1-4]\d{6}\b'
+            pattern: '(?<![A-Za-z0-9_])[0-9]{6}-[1-4][0-9]{6}(?![A-Za-z0-9_])'
             score: 0.9
           - entity-type: EMPLOYEE_ID
-            pattern: '\bEMP-\d{4}\b'
+            pattern: '(?<![A-Za-z0-9_])EMP-[0-9]{4}(?![A-Za-z0-9_])'
             score: 0.9
           - entity-type: CUSTOMER_ID
-            pattern: '\bCUST-\d{6}\b'
+            pattern: '(?<![A-Za-z0-9_])CUST-[0-9]{6}(?![A-Za-z0-9_])'
             score: 0.9
 
 ---

--- a/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/DemoRegexEvaluationTest.java
+++ b/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/DemoRegexEvaluationTest.java
@@ -72,7 +72,7 @@ class DemoRegexEvaluationTest {
                     .isZero();
         }
 
-        assertThat(cases).hasSize(62);
+        assertThat(cases).hasSize(64);
         assertThat(truePositives).isEqualTo(37);
         assertThat(falsePositives).isZero();
         assertThat(falseNegatives).isZero();

--- a/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/DemoRegexEvaluationTest.java
+++ b/samples/spring-ai-demo/src/test/java/io/github/ultramancode/springai/privacy/sample/DemoRegexEvaluationTest.java
@@ -72,8 +72,8 @@ class DemoRegexEvaluationTest {
                     .isZero();
         }
 
-        assertThat(cases).hasSize(64);
-        assertThat(truePositives).isEqualTo(37);
+        assertThat(cases).hasSize(68);
+        assertThat(truePositives).isEqualTo(38);
         assertThat(falsePositives).isZero();
         assertThat(falseNegatives).isZero();
     }

--- a/samples/spring-ai-demo/src/test/resources/privacy-evaluation-corpus.tsv
+++ b/samples/spring-ai-demo/src/test/resources/privacy-evaluation-corpus.tsv
@@ -45,10 +45,12 @@ phone-invalid-prefix	-	-	잘못된 휴대폰은 015-1234-5678입니다.
 phone-short-tail	-	-	짧은 번호는 010-1234-567입니다.
 phone-long-tail	-	-	긴 번호는 010-1234-56789입니다.
 phone-dotted	-	-	점 표기는 010.1234.5678입니다.
+phone-ascii-word-adjacency	-	-	A010-1234-5678B
 rrn-invalid-category	-	-	잘못된 식별값은 900101-5234567입니다.
 rrn-unhyphenated	-	-	붙여 쓴 식별값은 9001011234567입니다.
 rrn-short	-	-	짧은 식별값은 900101-123456입니다.
 rrn-long	-	-	긴 식별값은 900101-12345678입니다.
+rrn-ascii-word-adjacency	-	-	A900101-1234567B
 employee-lowercase	-	-	소문자 사번은 emp-1234입니다.
 employee-too-long	-	-	긴 사번은 EMP-12345입니다.
 employee-alpha	-	-	문자 사번은 EMP-ABCD입니다.

--- a/samples/spring-ai-demo/src/test/resources/privacy-evaluation-corpus.tsv
+++ b/samples/spring-ai-demo/src/test/resources/privacy-evaluation-corpus.tsv
@@ -25,6 +25,7 @@ customer-name-particle	-	-	고객명은 최민수가 맞습니다.
 email-subdomain	EMAIL_ADDRESS	user.name@privacy.example.io	알림 주소는 user.name@privacy.example.io입니다.
 email-short-local	EMAIL_ADDRESS	a@b.co	테스트 메일은 a@b.co입니다.
 email-uppercase	EMAIL_ADDRESS	SECURITY@EXAMPLE.ORG	보안 메일은 SECURITY@EXAMPLE.ORG입니다.
+email-trailing-period	EMAIL_ADDRESS	john@example.com	Email john@example.com.
 phone-016	PHONE_NUMBER	016-321-7654	예전 휴대폰은 016-321-7654입니다.
 phone-019	PHONE_NUMBER	019-987-6543	합성 연락처 019-987-6543을 사용합니다.
 phone-three-digit-middle	PHONE_NUMBER	010-123-4567	임시 번호는 010-123-4567입니다.
@@ -41,6 +42,7 @@ email-missing-domain	-	-	잘못된 메일은 user@입니다.
 email-double-at	-	-	잘못된 메일은 user@@example.com입니다.
 email-domain-underscore	-	-	허용하지 않는 예시는 user@example_domain입니다.
 email-one-letter-tld	-	-	짧은 도메인은 user@example.c입니다.
+email-ascii-word-adjacency	-	-	test@example.com_
 phone-invalid-prefix	-	-	잘못된 휴대폰은 015-1234-5678입니다.
 phone-short-tail	-	-	짧은 번호는 010-1234-567입니다.
 phone-long-tail	-	-	긴 번호는 010-1234-56789입니다.
@@ -54,10 +56,12 @@ rrn-ascii-word-adjacency	-	-	A900101-1234567B
 employee-lowercase	-	-	소문자 사번은 emp-1234입니다.
 employee-too-long	-	-	긴 사번은 EMP-12345입니다.
 employee-alpha	-	-	문자 사번은 EMP-ABCD입니다.
+employee-ascii-word-adjacency	-	-	AEMP-1234B
 customer-lowercase	-	-	소문자 고객번호는 cust-123456입니다.
 customer-too-short	-	-	짧은 고객번호는 CUST-12345입니다.
 customer-too-long	-	-	긴 고객번호는 CUST-1234567입니다.
 customer-separated	-	-	공백 고객번호는 CUST 123456입니다.
+customer-ascii-word-adjacency	-	-	ACUST-123456B
 person-five-syllables	-	-	제 이름은 가나다라마입니다.
 person-unrelated-label	-	-	사용자 이름은 홍길동입니다.
 json-ordinary	-	-	{"status":"public","count":1234}

--- a/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacySessionTest.java
+++ b/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacySessionTest.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -106,14 +108,18 @@ class PrivacySessionTest {
     }
 
     @Test
-    void sessionsRemainIsolatedAcrossVirtualThreads() throws Exception {
+    void sessionsRemainIsolatedAcrossConcurrentThreads() throws Exception {
         PrivacyService service = privacyService();
-        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
             CompletableFuture<String> alice = CompletableFuture.supplyAsync(() -> roundTrip(service, "Alice"), executor);
             CompletableFuture<String> bob = CompletableFuture.supplyAsync(() -> roundTrip(service, "Bob"), executor);
 
             assertThat(alice.get()).isEqualTo("Alice");
             assertThat(bob.get()).isEqualTo("Bob");
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
         }
         assertThat(service.activeSessionCount()).isZero();
     }

--- a/spring-ai-privacy-guardrails-opennlp/src/test/java/io/github/ultramancode/springai/privacy/opennlp/OpenNlpPiiAnalyzerTest.java
+++ b/spring-ai-privacy-guardrails-opennlp/src/test/java/io/github/ultramancode/springai/privacy/opennlp/OpenNlpPiiAnalyzerTest.java
@@ -21,8 +21,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -157,9 +159,10 @@ class OpenNlpPiiAnalyzerTest {
     }
 
     @Test
-    void analyzeIsSafeAcrossVirtualThreads() throws Exception {
+    void analyzeIsSafeAcrossConcurrentThreads() throws Exception {
         OpenNlpPiiAnalyzer analyzer = analyzer();
-        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
             List<Future<List<PiiSpan>>> futures = List.of(
                     executor.submit(() -> analyzer.analyze("Alice joined", PiiAnalysisOptions.defaults())),
                     executor.submit(() -> analyzer.analyze("Bob joined", PiiAnalysisOptions.defaults()))
@@ -169,6 +172,9 @@ class OpenNlpPiiAnalyzerTest {
             PiiSpan bob = futures.get(1).get().get(0);
             assertThat("Alice joined".substring(alice.start(), alice.end())).isEqualTo("Alice");
             assertThat("Bob joined".substring(bob.start(), bob.end())).isEqualTo("Bob");
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
         }
     }
 

--- a/spring-ai-privacy-guardrails-presidio/src/main/java/io/github/ultramancode/springai/privacy/presidio/PresidioAnalyzer.java
+++ b/spring-ai-privacy-guardrails-presidio/src/main/java/io/github/ultramancode/springai/privacy/presidio/PresidioAnalyzer.java
@@ -288,7 +288,7 @@ public final class PresidioAnalyzer implements PiiAnalyzer {
             return;
         }
         try {
-            Thread.sleep(duration);
+            TimeUnit.NANOSECONDS.sleep(TimeUnit.NANOSECONDS.convert(duration));
         } catch (InterruptedException interruption) {
             Thread.currentThread().interrupt();
             throw new PrivacyGuardrailException(

--- a/spring-ai-privacy-guardrails-presidio/src/test/java/io/github/ultramancode/springai/privacy/presidio/PresidioAnalyzerTest.java
+++ b/spring-ai-privacy-guardrails-presidio/src/test/java/io/github/ultramancode/springai/privacy/presidio/PresidioAnalyzerTest.java
@@ -16,6 +16,8 @@ import io.github.ultramancode.springai.privacy.core.PrivacyPhase;
 import io.github.ultramancode.springai.privacy.core.PrivacyService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -47,12 +49,13 @@ class PresidioAnalyzerTest {
     private ExecutorService serverExecutor;
 
     @AfterEach
-    void stopServer() {
+    void stopServer() throws InterruptedException {
         if (this.server != null) {
             this.server.stop(0);
         }
         if (this.serverExecutor != null) {
-            this.serverExecutor.close();
+            shutdownExecutor(this.serverExecutor);
+            this.serverExecutor = null;
         }
     }
 
@@ -204,7 +207,7 @@ class PresidioAnalyzerTest {
         PresidioAnalyzer analyzer = new PresidioAnalyzer(config(Duration.ofSeconds(5), 2));
         AtomicReference<Throwable> observedFailure = new AtomicReference<>();
         AtomicBoolean interruptRestored = new AtomicBoolean();
-        Thread analysisThread = Thread.ofVirtual().start(() -> {
+        Thread analysisThread = new Thread(() -> {
             try {
                 analyzer.analyze("Alice", PiiAnalysisOptions.defaults());
             } catch (Throwable failure) {
@@ -214,7 +217,8 @@ class PresidioAnalyzerTest {
         });
 
         try {
-            assertThat(partialBodyFlushed.await(2, TimeUnit.SECONDS)).isTrue();
+            analysisThread.start();
+            assertThat(partialBodyFlushed.await(5, TimeUnit.SECONDS)).isTrue();
             analysisThread.interrupt();
             analysisThread.join(2_000);
 
@@ -735,16 +739,26 @@ class PresidioAnalyzerTest {
     }
 
     @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
     void analyzeIsSafeToCallFromVirtualThreads() throws Exception {
         startServer(200, "[{\"entity_type\":\"PERSON\",\"start\":0,\"end\":5,\"score\":0.9}]");
         PresidioAnalyzer analyzer = new PresidioAnalyzer(config());
 
-        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+        ExecutorService executor = virtualThreadExecutor();
+        try {
             List<PiiSpan> result = executor.submit(
                     () -> analyzer.analyze("Alice", PiiAnalysisOptions.defaults())
             ).get();
             assertThat(result).containsExactly(new PiiSpan("PERSON", 0, 5, 0.9));
+        } finally {
+            shutdownExecutor(executor);
         }
+    }
+
+    private static ExecutorService virtualThreadExecutor() throws ReflectiveOperationException {
+        return (ExecutorService) Executors.class
+                .getMethod("newVirtualThreadPerTaskExecutor")
+                .invoke(null);
     }
 
     private PresidioAnalyzerConfig config() {
@@ -807,7 +821,7 @@ class PresidioAnalyzerTest {
 
     private void startConcurrentServer(HttpHandler handler) throws IOException {
         this.server = HttpServer.create(new InetSocketAddress(0), 0);
-        this.serverExecutor = Executors.newVirtualThreadPerTaskExecutor();
+        this.serverExecutor = Executors.newFixedThreadPool(2);
         this.server.setExecutor(this.serverExecutor);
         this.server.createContext("/analyze", handler);
         this.server.start();
@@ -857,5 +871,10 @@ class PresidioAnalyzerTest {
         exchange.sendResponseHeaders(status, body.length);
         exchange.getResponseBody().write(body);
         exchange.close();
+    }
+
+    private void shutdownExecutor(ExecutorService executor) throws InterruptedException {
+        executor.shutdownNow();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
     }
 }

--- a/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapperTest.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapperTest.java
@@ -10,6 +10,8 @@ import io.github.ultramancode.springai.privacy.core.PiiAnalysisOptions;
 import io.github.ultramancode.springai.privacy.core.PiiAnalyzer;
 import io.github.ultramancode.springai.privacy.core.PiiSpan;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -20,7 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -466,30 +470,42 @@ class PrivacyToolCallbackWrapperTest {
     }
 
     @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
     void scopedToolContextSurvivesVirtualThreadTransitionWithoutThreadLocal() throws Exception {
         PrivacyService service = TestPrivacyServices.privacyService();
-        try (PrivacySession session = service.openSession();
-                var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-            String token = service.tokenize(session.handle(), "Alice");
-            PrivacyToolCallbackWrapper wrapper = wrap(
-                    delegate(input -> {
-                        assertThat(input).isEqualTo("{\"query\":\"lookup Alice\"}");
-                        return "Alice found";
-                    }),
-                    service,
-                    ToolDisclosurePolicy.byToolName(Map.of("lookup", Set.of("PERSON")))
-            );
+        try (PrivacySession session = service.openSession()) {
+            ExecutorService executor = virtualThreadExecutor();
+            try {
+                String token = service.tokenize(session.handle(), "Alice");
+                PrivacyToolCallbackWrapper wrapper = wrap(
+                        delegate(input -> {
+                            assertThat(input).isEqualTo("{\"query\":\"lookup Alice\"}");
+                            return "Alice found";
+                        }),
+                        service,
+                        ToolDisclosurePolicy.byToolName(Map.of("lookup", Set.of("PERSON")))
+                );
 
-            String result = CompletableFuture.supplyAsync(
-                    () -> wrapper.call(
-                            "{\"query\":\"lookup " + token + "\"}",
-                            toolContext(session.handle())
-                    ),
-                    executor
-            ).get();
+                String result = CompletableFuture.supplyAsync(
+                        () -> wrapper.call(
+                                "{\"query\":\"lookup " + token + "\"}",
+                                toolContext(session.handle())
+                        ),
+                        executor
+                ).get();
 
-            assertThat(service.detokenize(session.handle(), result)).isEqualTo("Alice found");
+                assertThat(service.detokenize(session.handle(), result)).isEqualTo("Alice found");
+            } finally {
+                executor.shutdownNow();
+                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            }
         }
+    }
+
+    private static ExecutorService virtualThreadExecutor() throws ReflectiveOperationException {
+        return (ExecutorService) Executors.class
+                .getMethod("newVirtualThreadPerTaskExecutor")
+                .invoke(null);
     }
 
     @Test


### PR DESCRIPTION
## Summary

The library currently requires Java 21, but its production code does not depend on Java 21-only APIs or language features. Since Spring AI 2.0 and Spring Boot 4.1 support Java 17, the higher baseline is unnecessary for the current codebase.

This change lowers the source/bytecode baseline and default Java toolchain to Java 17, while keeping Java 21 and 25 in the CI compatibility matrix.

It also keeps virtual-thread compatibility coverage on Java 21+, verifies that the published artifacts can be consumed by Java 17 applications, and updates the sample ASCII-oriented regex boundaries to behave consistently across supported JDKs.

The user-facing compatibility documentation is updated to require Java 17 or later.

## Related Issue

Closes #24

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.