### PR TITLE
feat: expose privacy-safe enforcement outcomes

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [English](README.md) | [한국어](README.ko.md) | [Documentation](https://ultramancode.github.io/spring-ai-privacy-guardrails/)
 
 <!-- i18n-source: README.md -->
-<!-- i18n-source-sha256: 25de59e5a884e237304c5cb524eeab828b459f4db48eeba8e02a9e45d4530095 -->
+<!-- i18n-source-sha256: 7950caa98085af5e8695a777ee8be0cf603184bab4d12729ace74dfc320c261b -->
 
 <p align="center">
   <img src="docs/images/hero.svg" alt="Spring AI Privacy Guardrails 실행 경계" width="100%">
@@ -214,6 +214,16 @@ MCP처럼 실행 중에 도구 목록이 달라지는 `ToolCallbackProvider`는 
 
 구성별 세부 동작은 [설정과 사용법](docs/ko/configuration.md), 요청 흐름과 모듈 역할은
 [아키텍처](docs/ko/architecture.md)를 참고하세요.
+
+## 개인정보 보호 런타임 관측
+
+애플리케이션은 선택적으로 `PrivacyEnforcementObserver`를 등록해 모델·도구 입력·도구
+결과·애플리케이션 출력 경계에서 발생하는 개인정보 보호 처리 이벤트를 받을 수 있습니다.
+각 이벤트에는 이벤트가 발생한 경계(`boundary`)와 해당 경계의 처리 결과(`outcome`)만
+포함됩니다. 개인정보 원문, 토큰, 페이로드, 도구 이름과 요청 식별자는 포함되지 않습니다.
+
+등록 방법, 결과의 의미와 콜백 실행 지침은
+[개인정보 보호 런타임 관측](docs/ko/configuration.md#개인정보-보호-런타임-관측)을 참고하세요.
 
 ## 배포 모듈
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ See [Configuration](docs/configuration.md) for detailed behavior and
 [Architecture](docs/architecture.md) for request flow and module
 responsibilities.
 
+## Privacy-Safe Runtime Observation
+
+Applications can optionally register a `PrivacyEnforcementObserver` to receive
+privacy enforcement events at supported model, tool-input, tool-result, and
+application-output boundaries. Each event contains only `boundary`, identifying
+where it occurred, and `outcome`, describing the result at that boundary. It does
+not include PII, tokens, payloads, tool names, or request identifiers.
+
+See [Privacy-Safe Runtime Observation](docs/configuration.md#privacy-safe-runtime-observation)
+for registration, outcome semantics, and callback execution guidance.
+
 ## Published Modules
 
 Analyzer-specific starters bring in their runtime modules as transitive

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,6 +246,11 @@ failure category and processing phase.
 It cannot change the analysis result, and the information can be used for
 operational diagnostics such as metrics, tracing, and logs.
 
+The optional `PrivacyEnforcementObserver` reports `PROTECTED`, `DISCLOSED`, and
+`BLOCKED` outcomes at the model, tool-input, tool-result, and application-output
+boundaries. Events contain only `boundary` and `outcome`; observer failures
+cannot affect privacy enforcement.
+
 Exceptions raised by model providers, application tools, and external
 libraries may propagate using their original exception types. Exceptions and
 logs created outside the library are outside this sanitization boundary, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -652,6 +652,58 @@ environments. The try-with-resources pattern above clears captured records when
 the probe closes. Use `clear()` to reset only the recorded values while the
 probe remains open.
 
+## Privacy-Safe Runtime Observation
+
+Applications can register an optional Spring bean of type
+`PrivacyEnforcementObserver` to observe privacy enforcement at starter-managed
+boundaries:
+
+```java
+@Bean
+PrivacyEnforcementObserver privacyEnforcementObserver() {
+    return event -> privacyMetrics.record(event.boundary(), event.outcome());
+}
+```
+
+The observer receives an event each time a request passes through a supported
+privacy boundary. `boundary()` identifies where the event occurred, and
+`outcome()` describes the result at that boundary. A single request may therefore
+produce multiple events. If a request does not pass through a boundary, no event
+is delivered for that boundary. A boundary failure does not produce an empty
+outcome.
+
+`PrivacyEnforcementEvent` intentionally contains only `boundary()` and
+`outcome()`. It never includes raw PII, opaque tokens, entity types, payloads,
+tool names, request identifiers, or correlation data.
+
+| Boundary | When the event is delivered | Outcome and meaning |
+| --- | --- | --- |
+| `MODEL` | After protection of the request sent to the model completes | `PROTECTED` — model-request protection completed |
+| `TOOL_INPUT` | After tool-input handling completes | `DISCLOSED` — at least one original PII value was restored under policy<br>`PROTECTED` — no original PII value was restored for delivery to the tool |
+| `TOOL_RESULT` | After protection of the tool result completes | `PROTECTED` — tool-result protection completed |
+| `APPLICATION_OUTPUT` | When output protection is applied to the final response | `PROTECTED` — output protection completed and the response can be returned<br>`BLOCKED` — the `BLOCK` policy detected PII and raises a block exception instead of returning the response |
+
+`PROTECTED` means that protection at the boundary completed successfully. It
+does not indicate whether PII was present or whether content changed. For
+`TOOL_INPUT`, `PROTECTED` specifically means that no original PII value was
+restored for delivery to the tool.
+
+Streaming application output reports one event after protection of the complete
+buffered response finishes. Observer callbacks may run concurrently across
+requests. For streaming output, Reactor may invoke the callback on the thread
+processing the response stream rather than the thread that first handled the
+request; observers must not assume those threads are the same.
+
+Short operations such as logging and metrics updates can run directly. If
+network or database I/O is needed, enqueue the work and return promptly.
+Non-fatal observer failures are ignored and cannot change privacy enforcement.
+
+The Spring Boot starter automatically connects the registered observer bean.
+When constructing `PrivacyModelBoundaryAdvisor`, `PrivacyToolCallbackFactory`,
+or `PrivacyOutputAdvisor` directly without the starter's auto-configuration,
+pass the observer as a constructor argument. Existing constructors that do not
+accept an observer do not deliver observation events.
+
 ## Stored Data and Diagnostics
 
 This library protects PII in memory and retrieved documents when they are sent

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -439,6 +439,8 @@ Direct `ChatModel` calls and custom execution paths outside the configured
 
 - See [Configuration](configuration.md) for the complete property and API
   reference.
+- See [Privacy-Safe Runtime Observation](configuration.md#privacy-safe-runtime-observation)
+  to observe boundary outcomes without exposing PII or payloads.
 - See the [Sample / Demo Guide](sample.md) for Local Tool, RAG, and Streamable
   HTTP MCP runtime evidence.
 - See [Architecture](architecture.md) for model, tool, session, and request

--- a/docs/ko/architecture.md
+++ b/docs/ko/architecture.md
@@ -3,7 +3,7 @@
 [English](../architecture.md) | [한국어](architecture.md)
 
 <!-- i18n-source: docs/architecture.md -->
-<!-- i18n-source-sha256: ea4985b6522b23cb5e3db8f011be1fef4cc731124f422ba676a2a578b7131d10 -->
+<!-- i18n-source-sha256: 7cefceefe2799e4e372c7491b3d8b0b4dd699a96976763283f834a092ab00c11 -->
 
 ## 책임 범위
 
@@ -225,6 +225,11 @@ sequenceDiagram
 `PiiAnalyzerFailureObserver`도 같은 방식으로 정리된 실패 정보만 전달받습니다.
 이 정보는 분석 결과를 변경하지 않으며, 메트릭, 추적과 로그 같은 운영 진단에
 활용할 수 있습니다.
+
+선택적으로 등록할 수 있는 `PrivacyEnforcementObserver`는 모델, 도구 입력, 도구 결과,
+애플리케이션 출력 경계에서 발생한 `PROTECTED`, `DISCLOSED`, `BLOCKED` 결과를
+전달합니다. 이벤트에는 `boundary`와 `outcome`만 포함되며, 옵저버에서 오류가
+발생해도 개인정보 보호 처리에는 영향을 주지 않습니다.
 
 모델 제공자, 애플리케이션 도구와 외부 라이브러리에서 발생한 예외는 원래 예외
 유형으로 전달될 수 있습니다. 라이브러리 외부에서 생성된 예외와 로그는 이 정제

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -3,7 +3,7 @@
 [English](../configuration.md) | [한국어](configuration.md)
 
 <!-- i18n-source: docs/configuration.md -->
-<!-- i18n-source-sha256: 195674133ab92586897fa4941ad8e2c9ea8d7b09163f168a7efc62120cbddcf3 -->
+<!-- i18n-source-sha256: 68a4492bd4bbe162b50cb9b45971bf33b03db1a9e60e97ff23bd7ffddd9ff2ba -->
 
 이 문서는 Spring AI Privacy Guardrails를 사용하는 애플리케이션을 위한 종합
 참고 문서입니다. 기본 Spring Boot 스타터는 `core` 모듈과 Spring AI 통합 경계를
@@ -622,6 +622,54 @@ try (PrivacyTestProbe probe = PrivacyTestProbe.create(privacyService)) {
 `PrivacyTestProbe`에는 테스트 원문이 기록될 수 있으므로 테스트 환경에서만
 사용하세요. 위 예제처럼 try-with-resources로 사용하면 종료 시 기록이 정리됩니다.
 테스트 도중 기록만 초기화하려면 `clear()`를 사용할 수 있습니다.
+
+## 개인정보 보호 런타임 관측
+
+애플리케이션은 선택적으로 `PrivacyEnforcementObserver` 타입의 Spring 빈을 하나 등록해
+스타터가 관리하는 개인정보 보호 경계의 처리 결과를 받을 수 있습니다.
+
+```java
+@Bean
+PrivacyEnforcementObserver privacyEnforcementObserver() {
+    return event -> privacyMetrics.record(event.boundary(), event.outcome());
+}
+```
+
+옵저버는 요청이 지원되는 개인정보 보호 경계를 지날 때마다 이벤트를 전달합니다.
+`boundary()`는 이벤트가 발생한 지점을, `outcome()`은 해당 지점의 처리 결과를
+나타냅니다. 따라서 요청 하나에서 여러 이벤트가 발생할 수 있습니다. 요청이 특정
+경계를 지나지 않으면 해당 경계의 이벤트는 전달되지 않습니다. 경계 처리에 실패해도
+별도의 빈 결과를 전달하지 않습니다.
+
+`PrivacyEnforcementEvent`에는 의도적으로 `boundary()`와 `outcome()`만 포함됩니다.
+개인정보 원문, 불투명 토큰, 엔티티 유형, 페이로드, 도구 이름, 요청 식별자와
+상관관계 데이터는 전달하지 않습니다.
+
+| 경계 (`boundary`) | 이벤트 발생 시점 | 결과 (`outcome`)와 의미 |
+| --- | --- | --- |
+| `MODEL` | 모델에 전달할 요청의 보호 처리가 완료된 뒤 | `PROTECTED` — 모델 요청 보호가 완료됨 |
+| `TOOL_INPUT` | 도구 입력 처리가 완료된 뒤 | `DISCLOSED` — 정책에 따라 개인정보 원문을 하나 이상 복원함<br>`PROTECTED` — 도구에 전달하기 위해 복원된 개인정보 원문이 없음 |
+| `TOOL_RESULT` | 도구 결과의 보호 처리가 완료된 뒤 | `PROTECTED` — 도구 결과 보호가 완료됨 |
+| `APPLICATION_OUTPUT` | 최종 응답에 출력 보호를 적용할 때 | `PROTECTED` — 출력 보호가 완료되어 응답을 반환할 수 있음<br>`BLOCKED` — `BLOCK` 정책이 개인정보를 탐지해 응답 대신 차단 예외를 발생시킴 |
+
+`PROTECTED`는 해당 경계의 보호 처리가 정상적으로 완료됐다는 뜻입니다. 개인정보가
+있었는지 또는 실제 내용이 변경됐는지는 나타내지 않습니다. `TOOL_INPUT`에서
+`PROTECTED`는 도구에 전달하기 위해 복원된 개인정보 원문이 없다는 뜻입니다.
+
+스트리밍 애플리케이션 출력은 버퍼링된 전체 응답의 보호 처리가 끝난 뒤 이벤트를
+한 번만 전달합니다. 옵저버 콜백은 여러 요청에서 동시에 실행될 수 있습니다. 스트리밍
+출력에서는 Reactor가 응답 스트림을 처리하는 스레드에서 콜백을 실행할 수 있으므로,
+요청을 처음 처리한 스레드와 같다고 가정하면 안 됩니다.
+
+로그 기록이나 메트릭 갱신처럼 짧은 작업은 콜백에서 바로 수행해도 됩니다. 네트워크나
+데이터베이스 I/O가 필요하면 작업을 별도 큐에 넣고 콜백은 즉시 반환하는 방식을
+권장합니다. 옵저버 콜백에서 발생한 비치명적 오류는 무시되며 개인정보 보호 처리에는
+영향을 주지 않습니다.
+
+Spring Boot 스타터를 사용하면 등록한 옵저버 빈이 자동으로 연결됩니다. 스타터의 자동
+구성 없이 `PrivacyModelBoundaryAdvisor`, `PrivacyToolCallbackFactory`,
+`PrivacyOutputAdvisor`를 직접 생성하는 경우에는 옵저버를 생성자 인자로 전달해야
+합니다. 옵저버 인자가 없는 기존 생성자를 사용하면 관측 이벤트는 전달되지 않습니다.
 
 ## 저장 데이터와 진단 정보
 

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -3,7 +3,7 @@
 [English](../getting-started.md) | [한국어](getting-started.md)
 
 <!-- i18n-source: docs/getting-started.md -->
-<!-- i18n-source-sha256: 74ec755369d25288a429d77fc1619820b62fc988adaba189ee7025b712392df5 -->
+<!-- i18n-source-sha256: 0c3b2e4ef0b88eb57579f2dd02f13a3e737d5deb4cd888a637abadfc8d5c2510 -->
 
 이 가이드는 기존 Spring AI 애플리케이션에 Spring AI Privacy Guardrails를
 추가해 모델, 도구, MCP 및 출력 경계에 개인정보 보호를 적용하는 기본 사용 방법을
@@ -440,6 +440,8 @@ Regex, Presidio 또는 OpenNLP가 적합하지 않은 경우 애플리케이션�
 
 - 전체 설정 속성과 API 참고 문서는 [설정과 사용법](configuration.md)을
   참고하세요.
+- 개인정보 원문이나 페이로드를 노출하지 않고 경계 처리 결과만 관측하려면
+  [개인정보 보호 런타임 관측](configuration.md#개인정보-보호-런타임-관측)을 참고하세요.
 - 로컬 도구, RAG 및 Streamable HTTP MCP의 실제 실행 근거는
   [샘플 / 데모 가이드](sample.md)를 참고하세요.
 - 모델, 도구, 세션 및 요청 수명주기 경계는

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementBoundary.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementBoundary.java
@@ -1,0 +1,17 @@
+package io.github.ultramancode.springai.privacy.springai;
+
+/** Supported runtime boundary that completed a privacy-enforcement decision. */
+public enum PrivacyEnforcementBoundary {
+
+    /** Final request boundary immediately before model execution. */
+    MODEL,
+
+    /** Tool-argument boundary immediately before application tool execution. */
+    TOOL_INPUT,
+
+    /** Tool-result boundary before the result leaves the protected callback. */
+    TOOL_RESULT,
+
+    /** Final response boundary before content is returned to the application. */
+    APPLICATION_OUTPUT
+}

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementEvent.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementEvent.java
@@ -1,0 +1,23 @@
+package io.github.ultramancode.springai.privacy.springai;
+
+import java.util.Objects;
+
+/**
+ * Privacy-safe runtime enforcement event. The contract intentionally contains only
+ * a boundary and outcome: it carries no payload, PII, token, entity type, tool name,
+ * request identifier, or correlation data.
+ *
+ * @param boundary supported boundary that completed the decision
+ * @param outcome high-level enforcement outcome
+ */
+public record PrivacyEnforcementEvent(
+        PrivacyEnforcementBoundary boundary,
+        PrivacyEnforcementOutcome outcome
+) {
+
+    /** Validates that both privacy-safe event dimensions are present. */
+    public PrivacyEnforcementEvent {
+        Objects.requireNonNull(boundary, "boundary must not be null");
+        Objects.requireNonNull(outcome, "outcome must not be null");
+    }
+}

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementNotifier.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementNotifier.java
@@ -1,0 +1,27 @@
+package io.github.ultramancode.springai.privacy.springai;
+
+import io.github.ultramancode.springai.privacy.core.PrivacyFailureSanitizer;
+
+import java.util.Objects;
+
+/** Isolates optional enforcement observers from the privacy boundary. */
+final class PrivacyEnforcementNotifier {
+
+    private final PrivacyEnforcementObserver observer;
+
+    PrivacyEnforcementNotifier(PrivacyEnforcementObserver observer) {
+        this.observer = Objects.requireNonNull(observer, "observer must not be null");
+    }
+
+    void notify(
+            PrivacyEnforcementBoundary boundary,
+            PrivacyEnforcementOutcome outcome
+    ) {
+        PrivacyEnforcementEvent event = new PrivacyEnforcementEvent(boundary, outcome);
+        try {
+            this.observer.onEnforcement(event);
+        } catch (Throwable observerFailure) {
+            PrivacyFailureSanitizer.rethrowIfFatal(observerFailure);
+        }
+    }
+}

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementObserver.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementObserver.java
@@ -1,0 +1,29 @@
+package io.github.ultramancode.springai.privacy.springai;
+
+/**
+ * Receives privacy-safe runtime enforcement outcomes. Callbacks run inline and may be
+ * invoked concurrently. A streaming callback may run on a Reactor signal-processing
+ * thread rather than the original request thread. Implementations should return
+ * promptly and offload potentially blocking network or database I/O. Non-fatal
+ * observer failures are isolated and cannot change privacy enforcement.
+ */
+@FunctionalInterface
+public interface PrivacyEnforcementObserver {
+
+    /**
+     * Receives a privacy-safe event after a supported boundary completes its decision.
+     *
+     * @param event boundary and outcome only
+     */
+    void onEnforcement(PrivacyEnforcementEvent event);
+
+    /**
+     * Returns an observer that discards every event.
+     *
+     * @return a reusable no-operation observer
+     */
+    static PrivacyEnforcementObserver noop() {
+        return event -> {
+        };
+    }
+}

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementOutcome.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementOutcome.java
@@ -1,0 +1,17 @@
+package io.github.ultramancode.springai.privacy.springai;
+
+/** Privacy-safe outcome reported for a supported runtime boundary. */
+public enum PrivacyEnforcementOutcome {
+
+    /**
+     * The boundary completed its protection step. This outcome does not indicate
+     * whether the payload contained PII or required a content change.
+     */
+    PROTECTED,
+
+    /** At least one original value explicitly allowed by tool policy was restored. */
+    DISCLOSED,
+
+    /** The application-facing output policy blocked the response. */
+    BLOCKED
+}

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyJsonPayloadTransformer.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyJsonPayloadTransformer.java
@@ -85,18 +85,39 @@ final class PrivacyJsonPayloadTransformer {
             PrivacyPhase phase,
             boolean requireValidJson
     ) {
+        return discloseWithOutcome(
+                privacyService,
+                handle,
+                payload,
+                allowedEntityTypes,
+                phase,
+                requireValidJson
+        ).payload();
+    }
+
+    static DisclosureResult discloseWithOutcome(
+            PrivacyService privacyService,
+            PrivacyContextHandle handle,
+            String payload,
+            Set<String> allowedEntityTypes,
+            PrivacyPhase phase,
+            boolean requireValidJson
+    ) {
         Objects.requireNonNull(privacyService, "privacyService must not be null");
         Objects.requireNonNull(handle, "handle must not be null");
         Objects.requireNonNull(allowedEntityTypes, "allowedEntityTypes must not be null");
-        return analyzeAndTransformJsonOrText(
+        DisclosureTracker tracker = new DisclosureTracker();
+        String transformed = analyzeAndTransformJsonOrText(
                 privacyService,
                 handle,
                 payload,
                 phase,
                 requireValidJson,
                 PrivacyJsonScalarActionExecutor.Action.DISCLOSE,
-                allowedEntityTypes
+                allowedEntityTypes,
+                tracker
         );
+        return new DisclosureResult(transformed, tracker.disclosed());
     }
 
     static String restoreKnownTokens(
@@ -183,6 +204,28 @@ final class PrivacyJsonPayloadTransformer {
             PrivacyJsonScalarActionExecutor.Action action,
             Set<String> allowedEntityTypes
     ) {
+        return analyzeAndTransformJsonOrText(
+                privacyService,
+                handle,
+                payload,
+                phase,
+                requireValidJson,
+                action,
+                allowedEntityTypes,
+                null
+        );
+    }
+
+    private static String analyzeAndTransformJsonOrText(
+            PrivacyService privacyService,
+            PrivacyContextHandle handle,
+            String payload,
+            PrivacyPhase phase,
+            boolean requireValidJson,
+            PrivacyJsonScalarActionExecutor.Action action,
+            Set<String> allowedEntityTypes,
+            DisclosureTracker disclosureTracker
+    ) {
         Objects.requireNonNull(payload, "payload must not be null");
         Objects.requireNonNull(phase, "phase must not be null");
         requireWithinLimit(payload.length(), MAX_PAYLOAD_CHARACTERS, phase);
@@ -197,7 +240,8 @@ final class PrivacyJsonPayloadTransformer {
                     payload,
                     phase,
                     action,
-                    allowedEntityTypes
+                    allowedEntityTypes,
+                    disclosureTracker
             );
         } catch (PrivacyJsonDocumentProcessor.OutputLimitExceeded ignored) {
             throw payloadLimitExceeded(phase);
@@ -213,7 +257,8 @@ final class PrivacyJsonPayloadTransformer {
                     payload,
                     action,
                     allowedEntityTypes,
-                    phase
+                    phase,
+                    disclosureTracker
             );
         }
     }
@@ -224,7 +269,8 @@ final class PrivacyJsonPayloadTransformer {
             String payload,
             PrivacyPhase phase,
             PrivacyJsonScalarActionExecutor.Action action,
-            Set<String> allowedEntityTypes
+            Set<String> allowedEntityTypes,
+            DisclosureTracker disclosureTracker
     ) throws JacksonException {
         List<String> analysisTexts =
                 PrivacyJsonDocumentProcessor.validateAndCollectAnalysisTexts(payload, phase);
@@ -235,7 +281,7 @@ final class PrivacyJsonPayloadTransformer {
         );
         return PrivacyJsonDocumentProcessor.rewrite(
                 payload,
-                scalar -> PrivacyJsonScalarActionExecutor.apply(
+                scalar -> applyScalarAction(
                         privacyService,
                         handle,
                         scalar,
@@ -245,10 +291,46 @@ final class PrivacyJsonPayloadTransformer {
                         ),
                         action,
                         allowedEntityTypes,
-                        phase
+                        phase,
+                        disclosureTracker
                 ),
                 phase
         );
+    }
+
+    private static Object applyScalarAction(
+            PrivacyService privacyService,
+            PrivacyContextHandle handle,
+            Object scalar,
+            List<PiiSpan> spans,
+            PrivacyJsonScalarActionExecutor.Action action,
+            Set<String> allowedEntityTypes,
+            PrivacyPhase phase,
+            DisclosureTracker disclosureTracker
+    ) {
+        if (action != PrivacyJsonScalarActionExecutor.Action.DISCLOSE
+                || disclosureTracker == null) {
+            return PrivacyJsonScalarActionExecutor.apply(
+                    privacyService,
+                    handle,
+                    scalar,
+                    spans,
+                    action,
+                    allowedEntityTypes,
+                    phase
+            );
+        }
+        PrivacyJsonScalarActionExecutor.DisclosureResult result =
+                PrivacyJsonScalarActionExecutor.disclose(
+                        privacyService,
+                        handle,
+                        scalar,
+                        spans,
+                        allowedEntityTypes,
+                        phase
+                );
+        disclosureTracker.record(result.disclosed());
+        return result.value();
     }
 
     private static String applyTextAction(
@@ -257,7 +339,8 @@ final class PrivacyJsonPayloadTransformer {
             String text,
             PrivacyJsonScalarActionExecutor.Action action,
             Set<String> allowedEntityTypes,
-            PrivacyPhase phase
+            PrivacyPhase phase,
+            DisclosureTracker disclosureTracker
     ) {
         try {
             String transformedText = switch (action) {
@@ -269,11 +352,21 @@ final class PrivacyJsonPayloadTransformer {
                     }
                     yield text;
                 }
-                case DISCLOSE -> privacyService.detokenize(
-                        handle,
-                        privacyService.tokenize(handle, text),
-                        allowedEntityTypes
-                );
+                case DISCLOSE -> {
+                    var tokenization = privacyService.analyzeAndTokenize(handle, text);
+                    String disclosed = privacyService.detokenize(
+                            handle,
+                            tokenization.tokenizedText(),
+                            allowedEntityTypes
+                    );
+                    if (disclosureTracker != null) {
+                        disclosureTracker.record(!Objects.equals(
+                                tokenization.tokenizedText(),
+                                disclosed
+                        ));
+                    }
+                    yield disclosed;
+                }
             };
             return requireTransformedResult(transformedText, phase);
         } catch (PrivacyGuardrailException failure) {
@@ -338,6 +431,22 @@ final class PrivacyJsonPayloadTransformer {
 
         PiiDetected() {
             super(null, null, false, false);
+        }
+    }
+
+    record DisclosureResult(String payload, boolean disclosed) {
+    }
+
+    private static final class DisclosureTracker {
+
+        private boolean disclosed;
+
+        private void record(boolean disclosureOccurred) {
+            this.disclosed = this.disclosed || disclosureOccurred;
+        }
+
+        private boolean disclosed() {
+            return this.disclosed;
         }
     }
 }

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyJsonScalarActionExecutor.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyJsonScalarActionExecutor.java
@@ -8,6 +8,7 @@ import io.github.ultramancode.springai.privacy.core.PrivacyService;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /** Applies one privacy action to a pre-analyzed JSON scalar. */
@@ -47,16 +48,43 @@ final class PrivacyJsonScalarActionExecutor {
                     }
                     yield scalar;
                 }
-                case DISCLOSE -> privacyService.detokenizeValueTree(
+                case DISCLOSE -> disclose(
+                        privacyService,
                         handle,
-                        privacyService.tokenizeScalar(
-                                handle,
-                                scalar,
-                                tokenizationSpans(scalar, spans)
-                        ),
-                        allowedEntityTypes
-                );
+                        scalar,
+                        spans,
+                        allowedEntityTypes,
+                        phase
+                ).value();
             };
+        } catch (PrivacyGuardrailException failure) {
+            throw PrivacyJsonPayloadTransformer.remapOutputLimit(failure, phase);
+        }
+    }
+
+    static DisclosureResult disclose(
+            PrivacyService privacyService,
+            PrivacyContextHandle handle,
+            Object scalar,
+            List<PiiSpan> spans,
+            Set<String> allowedEntityTypes,
+            PrivacyPhase phase
+    ) {
+        try {
+            Object protectedScalar = privacyService.tokenizeScalar(
+                    handle,
+                    scalar,
+                    tokenizationSpans(scalar, spans)
+            );
+            Object disclosedScalar = privacyService.detokenizeValueTree(
+                    handle,
+                    protectedScalar,
+                    allowedEntityTypes
+            );
+            return new DisclosureResult(
+                    disclosedScalar,
+                    !Objects.equals(protectedScalar, disclosedScalar)
+            );
         } catch (PrivacyGuardrailException failure) {
             throw PrivacyJsonPayloadTransformer.remapOutputLimit(failure, phase);
         }
@@ -81,5 +109,8 @@ final class PrivacyJsonScalarActionExecutor {
         REDACT,
         CONTAINS_PII,
         DISCLOSE
+    }
+
+    record DisclosureResult(Object value, boolean disclosed) {
     }
 }

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyModelBoundaryAdvisor.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyModelBoundaryAdvisor.java
@@ -32,6 +32,7 @@ public final class PrivacyModelBoundaryAdvisor implements CallAdvisor, StreamAdv
     private final PrivacyMessageTransformer messageTransformer;
     private final PrivacyModelControlValidator modelControlValidator;
     private final PrivacyToolCallbackFactory.Provenance requiredFactoryProvenance;
+    private final PrivacyEnforcementNotifier enforcementNotifier;
     private final int order;
 
     /**
@@ -40,7 +41,7 @@ public final class PrivacyModelBoundaryAdvisor implements CallAdvisor, StreamAdv
      * @param privacyService service that owns request sessions and transformations
      */
     public PrivacyModelBoundaryAdvisor(PrivacyService privacyService) {
-        this(privacyService, null, DEFAULT_ORDER);
+        this(privacyService, null, PrivacyEnforcementObserver.noop(), DEFAULT_ORDER);
     }
 
     /**
@@ -50,7 +51,7 @@ public final class PrivacyModelBoundaryAdvisor implements CallAdvisor, StreamAdv
      * @param order Spring AI advisor order
      */
     public PrivacyModelBoundaryAdvisor(PrivacyService privacyService, int order) {
-        this(privacyService, null, order);
+        this(privacyService, null, PrivacyEnforcementObserver.noop(), order);
     }
 
     /**
@@ -64,7 +65,12 @@ public final class PrivacyModelBoundaryAdvisor implements CallAdvisor, StreamAdv
             PrivacyService privacyService,
             PrivacyToolCallbackFactory requiredFactory
     ) {
-        this(privacyService, requiredFactory, DEFAULT_ORDER);
+        this(
+                privacyService,
+                requiredFactory,
+                PrivacyEnforcementObserver.noop(),
+                DEFAULT_ORDER
+        );
     }
 
     /**
@@ -80,6 +86,29 @@ public final class PrivacyModelBoundaryAdvisor implements CallAdvisor, StreamAdv
             PrivacyToolCallbackFactory requiredFactory,
             int order
     ) {
+        this(
+                privacyService,
+                requiredFactory,
+                PrivacyEnforcementObserver.noop(),
+                order
+        );
+    }
+
+    /**
+     * Creates a factory-bound model boundary with an optional privacy-safe observer.
+     *
+     * @param privacyService service that owns request sessions and transformations
+     * @param requiredFactory factory whose wrappers are accepted, or {@code null} to
+     * accept wrappers from any factory using the same service
+     * @param enforcementObserver observer for boundary and outcome events only
+     * @param order Spring AI advisor order
+     */
+    public PrivacyModelBoundaryAdvisor(
+            PrivacyService privacyService,
+            PrivacyToolCallbackFactory requiredFactory,
+            PrivacyEnforcementObserver enforcementObserver,
+            int order
+    ) {
         this.privacyService = Objects.requireNonNull(privacyService, "privacyService must not be null");
         if (requiredFactory != null && !requiredFactory.usesPrivacyService(privacyService)) {
             throw new IllegalArgumentException("requiredFactory must use the same PrivacyService");
@@ -87,6 +116,7 @@ public final class PrivacyModelBoundaryAdvisor implements CallAdvisor, StreamAdv
         this.requiredFactoryProvenance = requiredFactory == null ? null : requiredFactory.provenance();
         this.messageTransformer = new PrivacyMessageTransformer(privacyService);
         this.modelControlValidator = new PrivacyModelControlValidator(privacyService);
+        this.enforcementNotifier = new PrivacyEnforcementNotifier(enforcementObserver);
         this.order = order;
     }
 
@@ -139,10 +169,15 @@ public final class PrivacyModelBoundaryAdvisor implements CallAdvisor, StreamAdv
                 : Set.of();
         this.modelControlValidator.validateModelVisibleToolDefinitions(handle, request);
         ChatClientRequest tokenized = this.messageTransformer.tokenize(handle, request);
-        return PrivacyToolExecutionContextSupport.attachRegisteredToolNames(
+        ChatClientRequest protectedRequest = PrivacyToolExecutionContextSupport.attachRegisteredToolNames(
                 tokenized,
                 registeredToolNames
         );
+        this.enforcementNotifier.notify(
+                PrivacyEnforcementBoundary.MODEL,
+                PrivacyEnforcementOutcome.PROTECTED
+        );
+        return protectedRequest;
     }
 
 }

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyOutputAdvisor.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyOutputAdvisor.java
@@ -48,6 +48,7 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
     private final String blockExceptionMessage;
     private final PrivacyResponseInspectionLimits responseInspectionLimits;
     private final PrivacyModelControlValidator modelControlValidator;
+    private final PrivacyEnforcementNotifier enforcementNotifier;
     private final int order;
 
     /**
@@ -61,6 +62,7 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
                 DEFAULT_ACTION,
                 DEFAULT_BLOCK_EXCEPTION_MESSAGE,
                 PrivacyResponseInspectionLimits.defaults(),
+                PrivacyEnforcementObserver.noop(),
                 DEFAULT_ORDER
         );
     }
@@ -78,6 +80,7 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
                 action,
                 blockExceptionMessage,
                 PrivacyResponseInspectionLimits.defaults(),
+                PrivacyEnforcementObserver.noop(),
                 DEFAULT_ORDER
         );
     }
@@ -101,6 +104,7 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
                 action,
                 blockExceptionMessage,
                 responseInspectionLimits,
+                PrivacyEnforcementObserver.noop(),
                 DEFAULT_ORDER
         );
     }
@@ -121,6 +125,60 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
             PrivacyResponseInspectionLimits responseInspectionLimits,
             int order
     ) {
+        this(
+                privacyService,
+                action,
+                blockExceptionMessage,
+                responseInspectionLimits,
+                PrivacyEnforcementObserver.noop(),
+                order
+        );
+    }
+
+    /**
+     * Creates an output boundary with an optional privacy-safe observer and default order.
+     *
+     * @param privacyService service that owns request sessions and transformations
+     * @param action action applied when sensitive output is detected
+     * @param blockExceptionMessage non-sensitive message used by {@link PrivacyOutputAction#BLOCK}
+     * @param responseInspectionLimits hard limits applied while inspecting call and stream responses
+     * @param enforcementObserver observer for boundary and outcome events only
+     */
+    public PrivacyOutputAdvisor(
+            PrivacyService privacyService,
+            PrivacyOutputAction action,
+            String blockExceptionMessage,
+            PrivacyResponseInspectionLimits responseInspectionLimits,
+            PrivacyEnforcementObserver enforcementObserver
+    ) {
+        this(
+                privacyService,
+                action,
+                blockExceptionMessage,
+                responseInspectionLimits,
+                enforcementObserver,
+                DEFAULT_ORDER
+        );
+    }
+
+    /**
+     * Creates an output boundary with an optional privacy-safe observer at a selected order.
+     *
+     * @param privacyService service that owns request sessions and transformations
+     * @param action action applied when sensitive output is detected
+     * @param blockExceptionMessage non-sensitive message used by {@link PrivacyOutputAction#BLOCK}
+     * @param responseInspectionLimits hard limits applied while inspecting call and stream responses
+     * @param enforcementObserver observer for boundary and outcome events only
+     * @param order Spring AI advisor order
+     */
+    public PrivacyOutputAdvisor(
+            PrivacyService privacyService,
+            PrivacyOutputAction action,
+            String blockExceptionMessage,
+            PrivacyResponseInspectionLimits responseInspectionLimits,
+            PrivacyEnforcementObserver enforcementObserver,
+            int order
+    ) {
         this.privacyService = Objects.requireNonNull(privacyService, "privacyService must not be null");
         this.action = Objects.requireNonNull(action, "action must not be null");
         if (blockExceptionMessage == null || blockExceptionMessage.isBlank()) {
@@ -132,6 +190,7 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
                 "responseInspectionLimits must not be null"
         );
         this.modelControlValidator = new PrivacyModelControlValidator(privacyService);
+        this.enforcementNotifier = new PrivacyEnforcementNotifier(enforcementObserver);
         this.order = order;
     }
 
@@ -156,6 +215,7 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
         new PrivacyResponseInspectionGuard(this.responseInspectionLimits).accept(response);
         ChatResponse originalChatResponse = response.chatResponse();
         if (originalChatResponse == null || originalChatResponse.getResults().isEmpty()) {
+            notifyApplicationOutput(PrivacyEnforcementOutcome.PROTECTED);
             return response;
         }
 
@@ -167,12 +227,16 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
             changed = changed || protectedGeneration != generation;
         }
 
-        if (!changed) {
-            return response;
+        ChatClientResponse protectedResponse = response;
+        if (changed) {
+            ChatResponse chatResponse = new ChatResponse(
+                    generations,
+                    originalChatResponse.getMetadata()
+            );
+            protectedResponse = response.mutate().chatResponse(chatResponse).build();
         }
-
-        ChatResponse chatResponse = new ChatResponse(generations, originalChatResponse.getMetadata());
-        return response.mutate().chatResponse(chatResponse).build();
+        notifyApplicationOutput(PrivacyEnforcementOutcome.PROTECTED);
+        return protectedResponse;
     }
 
     Flux<ChatClientResponse> protectAtApplicationBoundary(
@@ -267,6 +331,7 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
                 this.action
         );
         if (policyResult.blocked()) {
+            notifyApplicationOutput(PrivacyEnforcementOutcome.BLOCKED);
             throw new PrivacyOutputBlockedException(this.blockExceptionMessage);
         }
         return policyResult.text();
@@ -302,20 +367,22 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
                         return response;
                     })
                     .collectList()
-                    .flatMapMany(buffered -> Flux.fromIterable(
-                            PrivacyBufferedStreamTransformer.transform(
-                                    buffered,
-                                    (message, metadata) -> protectMessage(
-                                            handle,
-                                            message,
-                                            isReturnDirect(metadata)
-                                    ),
-                                    metadata -> PrivacyProviderTextMetadataTransformer.transformGenerationMetadata(
-                                            metadata,
-                                            text -> protectText(handle, text, isReturnDirect(metadata))
-                                    )
+                    .map(buffered -> PrivacyBufferedStreamTransformer.transform(
+                            buffered,
+                            (message, metadata) -> protectMessage(
+                                    handle,
+                                    message,
+                                    isReturnDirect(metadata)
+                            ),
+                            metadata -> PrivacyProviderTextMetadataTransformer.transformGenerationMetadata(
+                                    metadata,
+                                    text -> protectText(handle, text, isReturnDirect(metadata))
                             )
-                    ));
+                    ))
+                    .doOnNext(ignored -> notifyApplicationOutput(
+                            PrivacyEnforcementOutcome.PROTECTED
+                    ))
+                    .flatMapMany(Flux::fromIterable);
         });
     }
 
@@ -329,6 +396,13 @@ public final class PrivacyOutputAdvisor implements CallAdvisor, StreamAdvisor {
                 PrivacyFailureCode.STREAM_TIMEOUT,
                 PrivacyPhase.OUTPUT_POLICY,
                 "Streaming response exceeded the configured privacy idle timeout"
+        );
+    }
+
+    private void notifyApplicationOutput(PrivacyEnforcementOutcome outcome) {
+        this.enforcementNotifier.notify(
+                PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                outcome
         );
     }
 }

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackFactory.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackFactory.java
@@ -21,6 +21,7 @@ public final class PrivacyToolCallbackFactory {
 
     private final PrivacyService privacyService;
     private final ToolDisclosurePolicy disclosurePolicy;
+    private final PrivacyEnforcementNotifier enforcementNotifier;
     private final Provenance provenance = new Provenance();
 
     /**
@@ -33,11 +34,27 @@ public final class PrivacyToolCallbackFactory {
             PrivacyService privacyService,
             ToolDisclosurePolicy disclosurePolicy
     ) {
+        this(privacyService, disclosurePolicy, PrivacyEnforcementObserver.noop());
+    }
+
+    /**
+     * Creates a factory with an optional privacy-safe enforcement observer.
+     *
+     * @param privacyService service that owns request sessions and transformations
+     * @param disclosurePolicy least-privilege decision applied independently to each tool
+     * @param enforcementObserver observer for boundary and outcome events only
+     */
+    public PrivacyToolCallbackFactory(
+            PrivacyService privacyService,
+            ToolDisclosurePolicy disclosurePolicy,
+            PrivacyEnforcementObserver enforcementObserver
+    ) {
         this.privacyService = Objects.requireNonNull(privacyService, "privacyService must not be null");
         this.disclosurePolicy = Objects.requireNonNull(
                 disclosurePolicy,
                 "disclosurePolicy must not be null"
         );
+        this.enforcementNotifier = new PrivacyEnforcementNotifier(enforcementObserver);
     }
 
     /**
@@ -158,6 +175,7 @@ public final class PrivacyToolCallbackFactory {
                 delegate,
                 this.privacyService,
                 this.disclosurePolicy,
+                this.enforcementNotifier,
                 this.provenance
         );
     }

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapper.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyToolCallbackWrapper.java
@@ -28,17 +28,23 @@ final class PrivacyToolCallbackWrapper implements ToolCallback {
     private final ToolMetadata toolMetadata;
     private final PrivacyService privacyService;
     private final ToolDisclosurePolicy disclosurePolicy;
+    private final PrivacyEnforcementNotifier enforcementNotifier;
     private final PrivacyToolCallbackFactory.Provenance factoryProvenance;
 
     PrivacyToolCallbackWrapper(
             ToolCallback delegate,
             PrivacyService privacyService,
             ToolDisclosurePolicy disclosurePolicy,
+            PrivacyEnforcementNotifier enforcementNotifier,
             PrivacyToolCallbackFactory.Provenance factoryProvenance
     ) {
         this.delegate = delegate;
         this.privacyService = privacyService;
         this.disclosurePolicy = disclosurePolicy;
+        this.enforcementNotifier = Objects.requireNonNull(
+                enforcementNotifier,
+                "enforcementNotifier must not be null"
+        );
         this.factoryProvenance = Objects.requireNonNull(
                 factoryProvenance,
                 "factoryProvenance must not be null"
@@ -83,8 +89,19 @@ final class PrivacyToolCallbackWrapper implements ToolCallback {
         Objects.requireNonNull(toolInput, "toolInput must not be null");
         PrivacyContextHandle handle = requireActiveHandle(toolContext);
         ToolDisclosureScope disclosureScope = disclosureScope();
-        String cleanInput = transformInput(handle, toolInput, disclosureScope);
+        PrivacyJsonPayloadTransformer.DisclosureResult inputResult = transformInput(
+                handle,
+                toolInput,
+                disclosureScope
+        );
+        String cleanInput = inputResult.payload();
         ToolContext delegateContext = withoutInternalPrivacyEntries(toolContext);
+        this.enforcementNotifier.notify(
+                PrivacyEnforcementBoundary.TOOL_INPUT,
+                inputResult.disclosed()
+                        ? PrivacyEnforcementOutcome.DISCLOSED
+                        : PrivacyEnforcementOutcome.PROTECTED
+        );
         String delegateResult = this.delegate.call(cleanInput, delegateContext);
         if (delegateResult == null) {
             throw new ToolExecutionException(
@@ -96,7 +113,12 @@ final class PrivacyToolCallbackWrapper implements ToolCallback {
                     )
             );
         }
-        return tokenizeResult(handle, delegateResult);
+        String protectedResult = tokenizeResult(handle, delegateResult);
+        this.enforcementNotifier.notify(
+                PrivacyEnforcementBoundary.TOOL_RESULT,
+                PrivacyEnforcementOutcome.PROTECTED
+        );
+        return protectedResult;
     }
 
     private ToolDisclosureScope disclosureScope() {
@@ -111,12 +133,12 @@ final class PrivacyToolCallbackWrapper implements ToolCallback {
         return scope;
     }
 
-    private String transformInput(
+    private PrivacyJsonPayloadTransformer.DisclosureResult transformInput(
             PrivacyContextHandle handle,
             String toolInput,
             ToolDisclosureScope disclosureScope
     ) {
-        return PrivacyJsonPayloadTransformer.disclose(
+        return PrivacyJsonPayloadTransformer.discloseWithOutcome(
                 this.privacyService,
                 handle,
                 toolInput,

--- a/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementObserverTest.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementObserverTest.java
@@ -1,0 +1,316 @@
+package io.github.ultramancode.springai.privacy.springai;
+
+import io.github.ultramancode.springai.privacy.core.PrivacyContextHandle;
+import io.github.ultramancode.springai.privacy.core.PrivacyService;
+import io.github.ultramancode.springai.privacy.core.PrivacySession;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import reactor.core.publisher.Flux;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PrivacyEnforcementObserverTest {
+
+    @Test
+    void eventContractExposesOnlyBoundaryAndOutcome() {
+        assertThat(Arrays.stream(PrivacyEnforcementEvent.class.getRecordComponents())
+                .map(RecordComponent::getName))
+                .containsExactly("boundary", "outcome");
+        assertThat(Arrays.stream(PrivacyEnforcementEvent.class.getRecordComponents())
+                .map(RecordComponent::getType))
+                .containsExactly(
+                        PrivacyEnforcementBoundary.class,
+                        PrivacyEnforcementOutcome.class
+                );
+    }
+
+    @Test
+    void supportedBoundariesReportOnlyHighLevelEnforcementOutcomes() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyEnforcementObserver observer = events::add;
+        PrivacyModelBoundaryAdvisor modelBoundary = new PrivacyModelBoundaryAdvisor(
+                service,
+                null,
+                observer,
+                PrivacyModelBoundaryAdvisor.DEFAULT_ORDER
+        );
+        PrivacyToolCallbackFactory toolFactory = new PrivacyToolCallbackFactory(
+                service,
+                ToolDisclosurePolicy.byToolName(Map.of("lookup", Set.of("PERSON"))),
+                observer
+        );
+        PrivacyOutputAdvisor outputBoundary = new PrivacyOutputAdvisor(
+                service,
+                PrivacyOutputAction.TOKENIZE,
+                "blocked",
+                PrivacyResponseInspectionLimits.defaults(),
+                observer
+        );
+        CallAdvisorChain chain = mock(CallAdvisorChain.class);
+        when(chain.nextCall(any())).thenReturn(TestPrivacyServices.response("safe"));
+
+        try (PrivacySession session = service.openSession()) {
+            modelBoundary.adviseCall(activeRequest("Alice", session.handle()), chain);
+
+            String personToken = service.tokenize(session.handle(), "Alice");
+            ToolCallback protectedTool = toolFactory.wrap(tool(input -> {
+                assertThat(input).contains("Alice").doesNotContain("[[PII_");
+                return "Bob";
+            }));
+            String protectedResult = protectedTool.call(
+                    "{\"name\":\"" + personToken + "\"}",
+                    toolContext(session.handle())
+            );
+            assertThat(protectedResult).doesNotContain("Bob");
+
+            outputBoundary.protectAtApplicationBoundary(
+                    session.handle(),
+                    response("Alice")
+            );
+        }
+
+        assertThat(events).containsExactly(
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.MODEL,
+                        PrivacyEnforcementOutcome.PROTECTED
+                ),
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.TOOL_INPUT,
+                        PrivacyEnforcementOutcome.DISCLOSED
+                ),
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.TOOL_RESULT,
+                        PrivacyEnforcementOutcome.PROTECTED
+                ),
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                        PrivacyEnforcementOutcome.PROTECTED
+                )
+        );
+        assertThat(events.toString()).doesNotContain("Alice", "Bob", "PERSON", "[[PII_");
+    }
+
+    @Test
+    void blockedApplicationOutputReportsBlockedBeforeTheSafeExceptionEscapes() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyOutputAdvisor outputBoundary = new PrivacyOutputAdvisor(
+                service,
+                PrivacyOutputAction.BLOCK,
+                "blocked",
+                PrivacyResponseInspectionLimits.defaults(),
+                events::add
+        );
+
+        try (PrivacySession session = service.openSession()) {
+            assertThatThrownBy(() -> outputBoundary.protectAtApplicationBoundary(
+                    session.handle(),
+                    response("Alice")
+            ))
+                    .isInstanceOf(PrivacyOutputBlockedException.class)
+                    .hasMessage("blocked");
+        }
+
+        assertThat(events).containsExactly(new PrivacyEnforcementEvent(
+                PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                PrivacyEnforcementOutcome.BLOCKED
+        ));
+    }
+
+    @Test
+    void allowedToolScopeWithoutAnOriginalRestorationReportsProtected() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyToolCallbackFactory toolFactory = new PrivacyToolCallbackFactory(
+                service,
+                ToolDisclosurePolicy.byToolName(Map.of("lookup", Set.of("PERSON"))),
+                events::add
+        );
+        ToolCallback protectedTool = toolFactory.wrap(tool(input -> "safe result"));
+
+        try (PrivacySession session = service.openSession()) {
+            protectedTool.call(
+                    " { \"query\" : \"safe\" } ",
+                    toolContext(session.handle())
+            );
+        }
+
+        assertThat(events).containsExactly(
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.TOOL_INPUT,
+                        PrivacyEnforcementOutcome.PROTECTED
+                ),
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.TOOL_RESULT,
+                        PrivacyEnforcementOutcome.PROTECTED
+                )
+        );
+    }
+
+    @Test
+    void streamingApplicationOutputReportsOnceAfterTheLogicalResponseCompletes() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyOutputAdvisor outputBoundary = new PrivacyOutputAdvisor(
+                service,
+                PrivacyOutputAction.TOKENIZE,
+                "blocked",
+                PrivacyResponseInspectionLimits.defaults(),
+                events::add
+        );
+
+        try (PrivacySession session = service.openSession()) {
+            outputBoundary.protectAtApplicationBoundary(
+                    session.handle(),
+                    Flux.just(response("Alice"))
+            ).collectList().block();
+        }
+
+        assertThat(events).containsExactly(new PrivacyEnforcementEvent(
+                PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                PrivacyEnforcementOutcome.PROTECTED
+        ));
+    }
+
+    @Test
+    void streamingApplicationOutputReportsAfterProtectionWhenReplayIsCancelled() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyOutputAdvisor outputBoundary = new PrivacyOutputAdvisor(
+                service,
+                PrivacyOutputAction.TOKENIZE,
+                "blocked",
+                PrivacyResponseInspectionLimits.defaults(),
+                events::add
+        );
+
+        try (PrivacySession session = service.openSession()) {
+            ChatClientResponse firstResponse = outputBoundary.protectAtApplicationBoundary(
+                    session.handle(),
+                    Flux.just(response("safe-"), response("response"))
+            ).next().block();
+            assertThat(firstResponse).isNotNull();
+        }
+
+        assertThat(events).containsExactly(new PrivacyEnforcementEvent(
+                PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                PrivacyEnforcementOutcome.PROTECTED
+        ));
+    }
+
+    @Test
+    void streamingApplicationOutputReportsBlockedOnlyForItsOwnPolicyDecision() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyOutputAdvisor outputBoundary = new PrivacyOutputAdvisor(
+                service,
+                PrivacyOutputAction.BLOCK,
+                "blocked",
+                PrivacyResponseInspectionLimits.defaults(),
+                events::add
+        );
+
+        PrivacyOutputBlockedException upstreamFailure =
+                new PrivacyOutputBlockedException("upstream blocked");
+        try (PrivacySession session = service.openSession()) {
+            assertThatThrownBy(() -> outputBoundary.protectAtApplicationBoundary(
+                    session.handle(),
+                    Flux.<ChatClientResponse>error(upstreamFailure)
+            ).collectList().block()).isSameAs(upstreamFailure);
+        }
+        assertThat(events).isEmpty();
+
+        try (PrivacySession session = service.openSession()) {
+            assertThatThrownBy(() -> outputBoundary.protectAtApplicationBoundary(
+                    session.handle(),
+                    Flux.just(response("Alice"))
+            ).collectList().block())
+                    .isInstanceOf(PrivacyOutputBlockedException.class)
+                    .hasMessage("blocked");
+        }
+        assertThat(events).containsExactly(new PrivacyEnforcementEvent(
+                PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                PrivacyEnforcementOutcome.BLOCKED
+        ));
+    }
+
+    @Test
+    void nonFatalObserverFailuresCannotChangePrivacyEnforcement() {
+        PrivacyEnforcementNotifier notifier = new PrivacyEnforcementNotifier(event -> {
+            throw new IllegalStateException("observer unavailable");
+        });
+
+        assertThatCode(() -> notifier.notify(
+                PrivacyEnforcementBoundary.MODEL,
+                PrivacyEnforcementOutcome.PROTECTED
+        )).doesNotThrowAnyException();
+    }
+
+    private ChatClientRequest activeRequest(String text, PrivacyContextHandle handle) {
+        ChatClientRequest request = new ChatClientRequest(new Prompt(text), Map.of());
+        return PrivacyToolExecutionContextSupport.attachValidatedToolCallbackSnapshot(
+                PrivacyRequestContextSupport.attachLifecycle(request, handle)
+        );
+    }
+
+    private ToolContext toolContext(PrivacyContextHandle handle) {
+        return new ToolContext(Map.of(PrivacyRequestContextSupport.CONTEXT_HANDLE, handle));
+    }
+
+    private ToolCallback tool(Callback callback) {
+        return new ToolCallback() {
+            @Override
+            public ToolDefinition getToolDefinition() {
+                return ToolDefinition.builder()
+                        .name("lookup")
+                        .description("lookup")
+                        .inputSchema("{}")
+                        .build();
+            }
+
+            @Override
+            public String call(String toolInput) {
+                return callback.call(toolInput);
+            }
+
+            @Override
+            public String call(String toolInput, ToolContext toolContext) {
+                return callback.call(toolInput);
+            }
+        };
+    }
+
+    private ChatClientResponse response(String text) {
+        return new ChatClientResponse(
+                new ChatResponse(List.of(new Generation(new AssistantMessage(text)))),
+                Map.of()
+        );
+    }
+
+    @FunctionalInterface
+    private interface Callback {
+        String call(String input);
+    }
+}

--- a/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementObserverTest.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyEnforcementObserverTest.java
@@ -8,10 +8,12 @@ import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import reactor.core.publisher.Flux;
@@ -167,6 +169,81 @@ class PrivacyEnforcementObserverTest {
                         PrivacyEnforcementOutcome.PROTECTED
                 )
         );
+    }
+
+    @Test
+    void disallowedProtectedToolInputReportsProtected() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyToolCallbackFactory toolFactory = new PrivacyToolCallbackFactory(
+                service,
+                ToolDisclosurePolicy.denyAll(),
+                events::add
+        );
+
+        try (PrivacySession session = service.openSession()) {
+            String personToken = service.tokenize(session.handle(), "Alice");
+            ToolCallback protectedTool = toolFactory.wrap(tool(input -> {
+                assertThat(input).contains(personToken).doesNotContain("Alice");
+                return "safe result";
+            }));
+
+            protectedTool.call(
+                    "{\"name\":\"" + personToken + "\"}",
+                    toolContext(session.handle())
+            );
+        }
+
+        assertThat(events).containsExactly(
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.TOOL_INPUT,
+                        PrivacyEnforcementOutcome.PROTECTED
+                ),
+                new PrivacyEnforcementEvent(
+                        PrivacyEnforcementBoundary.TOOL_RESULT,
+                        PrivacyEnforcementOutcome.PROTECTED
+                )
+        );
+    }
+
+    @Test
+    void returnDirectApplicationOutputReportsProtectedExactlyOnce() {
+        PrivacyService service = TestPrivacyServices.privacyService();
+        List<PrivacyEnforcementEvent> events = new ArrayList<>();
+        PrivacyOutputAdvisor outputBoundary = new PrivacyOutputAdvisor(
+                service,
+                PrivacyOutputAction.REDACT,
+                "blocked",
+                PrivacyResponseInspectionLimits.defaults(),
+                events::add
+        );
+
+        try (PrivacySession session = service.openSession()) {
+            String personToken = service.tokenize(session.handle(), "Alice");
+            Generation returnDirectGeneration = new Generation(
+                    new AssistantMessage(personToken),
+                    ChatGenerationMetadata.builder()
+                            .finishReason(ToolExecutionResult.FINISH_REASON)
+                            .build()
+            );
+
+            ChatClientResponse protectedResponse = outputBoundary.protectAtApplicationBoundary(
+                    session.handle(),
+                    new ChatClientResponse(
+                            new ChatResponse(List.of(returnDirectGeneration)),
+                            Map.of()
+                    )
+            );
+
+            assertThat(protectedResponse.chatResponse().getResult().getOutput().getText())
+                    .contains("[REDACTED_PERSON]")
+                    .doesNotContain("Alice", "[[PII_");
+        }
+
+        assertThat(events).containsExactly(new PrivacyEnforcementEvent(
+                PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                PrivacyEnforcementOutcome.PROTECTED
+        ));
     }
 
     @Test

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfiguration.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/main/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfiguration.java
@@ -9,6 +9,7 @@ import io.github.ultramancode.springai.privacy.core.PrivacyService;
 import io.github.ultramancode.springai.privacy.core.RegexPiiAnalyzer;
 import io.github.ultramancode.springai.privacy.core.RegexPiiMatchValidator;
 import io.github.ultramancode.springai.privacy.core.RegexPiiRule;
+import io.github.ultramancode.springai.privacy.springai.PrivacyEnforcementObserver;
 import io.github.ultramancode.springai.privacy.springai.PrivacyInputAdvisor;
 import io.github.ultramancode.springai.privacy.springai.PrivacyLifecycleAdvisor;
 import io.github.ultramancode.springai.privacy.springai.PrivacyModelBoundaryAdvisor;
@@ -196,8 +197,11 @@ public class PrivacyGuardrailsAutoConfiguration {
     PrivacyChatClientConfigurer privacyChatClientConfigurer(
             PrivacyService privacyService,
             PrivacyToolCallbackFactory toolCallbackFactory,
-            PrivacyGuardrailsProperties properties
+            PrivacyGuardrailsProperties properties,
+            ObjectProvider<PrivacyEnforcementObserver> enforcementObserver
     ) {
+        PrivacyEnforcementObserver configuredEnforcementObserver = enforcementObserver
+                .getIfAvailable(PrivacyEnforcementObserver::noop);
         PrivacyGuardrailsProperties.Output outputProperties = properties.getOutput();
         PrivacyResponseInspectionLimits responseInspectionLimits =
                 properties.getResponseInspection().limits();
@@ -209,7 +213,8 @@ public class PrivacyGuardrailsAutoConfiguration {
                     privacyService,
                     outputProperties.getAction(),
                     outputProperties.getBlockExceptionMessage(),
-                    responseInspectionLimits
+                    responseInspectionLimits,
+                    configuredEnforcementObserver
             ));
         }
         advisors.add(new PrivacyToolContextAdvisor(privacyService, toolCallbackFactory));
@@ -219,7 +224,9 @@ public class PrivacyGuardrailsAutoConfiguration {
         ));
         advisors.add(new PrivacyModelBoundaryAdvisor(
                 privacyService,
-                toolCallbackFactory
+                toolCallbackFactory,
+                configuredEnforcementObserver,
+                PrivacyModelBoundaryAdvisor.DEFAULT_ORDER
         ));
         return new PrivacyChatClientConfigurer(advisors);
     }
@@ -234,9 +241,14 @@ public class PrivacyGuardrailsAutoConfiguration {
     @ConditionalOnMissingBean
     PrivacyToolCallbackFactory privacyToolCallbackFactory(
             PrivacyService privacyService,
-            ToolDisclosurePolicy toolDisclosurePolicy
+            ToolDisclosurePolicy toolDisclosurePolicy,
+            ObjectProvider<PrivacyEnforcementObserver> enforcementObserver
     ) {
-        return new PrivacyToolCallbackFactory(privacyService, toolDisclosurePolicy);
+        return new PrivacyToolCallbackFactory(
+                privacyService,
+                toolDisclosurePolicy,
+                enforcementObserver.getIfAvailable(PrivacyEnforcementObserver::noop)
+        );
     }
 
 }

--- a/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfigurationTest.java
+++ b/spring-ai-privacy-guardrails-spring-boot-starter/src/test/java/io/github/ultramancode/springai/privacy/autoconfigure/PrivacyGuardrailsAutoConfigurationTest.java
@@ -16,6 +16,10 @@ import io.github.ultramancode.springai.privacy.core.RegexPiiAnalyzer;
 import io.github.ultramancode.springai.privacy.core.RegexPiiMatchValidator;
 import io.github.ultramancode.springai.privacy.core.RegexPiiRule;
 import io.github.ultramancode.springai.privacy.core.ResolvedPiiSpan;
+import io.github.ultramancode.springai.privacy.springai.PrivacyEnforcementBoundary;
+import io.github.ultramancode.springai.privacy.springai.PrivacyEnforcementEvent;
+import io.github.ultramancode.springai.privacy.springai.PrivacyEnforcementObserver;
+import io.github.ultramancode.springai.privacy.springai.PrivacyEnforcementOutcome;
 import io.github.ultramancode.springai.privacy.springai.PrivacyInputAdvisor;
 import io.github.ultramancode.springai.privacy.springai.PrivacyLifecycleAdvisor;
 import io.github.ultramancode.springai.privacy.springai.PrivacyModelBoundaryAdvisor;
@@ -488,6 +492,7 @@ class PrivacyGuardrailsAutoConfigurationTest {
     @Test
     void explicitConfigurerRunsCompleteToolLoopOutputPolicyAndSessionCleanup() {
         AtomicReference<String> delegateToolInput = new AtomicReference<>();
+        List<PrivacyEnforcementEvent> enforcementEvents = new CopyOnWriteArrayList<>();
         this.contextRunner
                 .withBean(RegexPiiAnalyzer.class, () -> new RegexPiiAnalyzer(List.of(
                         new RegexPiiRule("CUSTOMER_ID", "\\bCUST-\\d{4}\\b", 0.99, 0),
@@ -498,6 +503,7 @@ class PrivacyGuardrailsAutoConfigurationTest {
                                 0
                         )
                 )))
+                .withBean(PrivacyEnforcementObserver.class, () -> enforcementEvents::add)
                 .withPropertyValues(
                         "spring.ai.privacy.output.enabled=true",
                         "spring.ai.privacy.tools.disclosures[customerLookup][0]=CUSTOMER_ID"
@@ -534,6 +540,31 @@ class PrivacyGuardrailsAutoConfigurationTest {
                     assertThat(result)
                             .doesNotContain("final@example.test")
                             .containsPattern(OpaquePiiTokenFormat.patternForEntityType("EMAIL_ADDRESS"));
+                    assertThat(enforcementEvents).contains(
+                            new PrivacyEnforcementEvent(
+                                    PrivacyEnforcementBoundary.MODEL,
+                                    PrivacyEnforcementOutcome.PROTECTED
+                            ),
+                            new PrivacyEnforcementEvent(
+                                    PrivacyEnforcementBoundary.TOOL_INPUT,
+                                    PrivacyEnforcementOutcome.DISCLOSED
+                            ),
+                            new PrivacyEnforcementEvent(
+                                    PrivacyEnforcementBoundary.TOOL_RESULT,
+                                    PrivacyEnforcementOutcome.PROTECTED
+                            ),
+                            new PrivacyEnforcementEvent(
+                                    PrivacyEnforcementBoundary.APPLICATION_OUTPUT,
+                                    PrivacyEnforcementOutcome.PROTECTED
+                            )
+                    );
+                    assertThat(enforcementEvents.toString()).doesNotContain(
+                            "CUST-0042",
+                            "user@example.test",
+                            "CUSTOMER_ID",
+                            "EMAIL_ADDRESS",
+                            "[[PII_"
+                    );
                     assertThat(context.getBean(PrivacyService.class).activeSessionCount()).isZero();
                 });
     }


### PR DESCRIPTION
## Summary

`PiiAnalyzerFailureObserver` reports sanitized analyzer failures, and `PrivacyTestProbe` supports test-only boundary verification, but applications previously had no privacy-safe signal for runtime enforcement outcomes.

This change adds an optional `PrivacyEnforcementObserver` contract for model, tool-input, tool-result, and application-output boundaries. Depending on the boundary, it reports `PROTECTED`, `DISCLOSED`, or `BLOCKED`. Events intentionally expose only `boundary` and `outcome`; they carry no raw PII, opaque tokens, entity types, payload content, tool names, or request correlation data.

The observer is optional. Spring Boot auto-configuration wires a `PrivacyEnforcementObserver` bean when present, while applications without auto-configuration can opt in through observer-aware constructors. Privacy enforcement continues unchanged when no observer is configured, and non-fatal observer failures cannot affect enforcement.

Tests cover the new observer contract across the Spring AI and Spring Boot integration paths, and the corresponding English and Korean documentation is updated.

## Related Issue

Closes #22

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.