### PR TITLE
build: update Spring AI compatibility baseline to 2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
           publishedPomOnlyArtifactSmokeTest
           -PtestJavaVersion=17
 
+      - name: Verify Spring AI 2.0.0 patch compatibility
+        if: matrix.java == 17
+        run: |
+          ./gradlew --no-daemon clean test \
+            -PspringAiVersion=2.0.0 \
+            -PtestJavaVersion=17
+          ./gradlew --no-daemon \
+            publishedArtifactSmokeTest \
+            publishedPomOnlyArtifactSmokeTest \
+            -PspringAiVersion=2.0.0 \
+            -PtestJavaVersion=17
+
       - name: Verify Javadoc and publication metadata
         if: matrix.java == 21
         run: >-

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [English](README.md) | [한국어](README.ko.md) | [Documentation](https://ultramancode.github.io/spring-ai-privacy-guardrails/)
 
 <!-- i18n-source: README.md -->
-<!-- i18n-source-sha256: a99edee37016e43d18ccf9bdd14cf098c980951e9c1b3647f34702435d85e562 -->
+<!-- i18n-source-sha256: 6e1a421c9df07f5db7aec1f78d4b3e8ba1ca60a5776f88fea343e59c9b3817d9 -->
 
 <p align="center">
   <img src="docs/images/hero.svg" alt="Spring AI Privacy Guardrails 실행 경계" width="100%">
@@ -246,12 +246,15 @@ JMH 벤치마크는 라이브러리로 배포되지 않으며, 측정 대상과 
 
 | 구성 요소 | 현재 검증 기준 |
 | --- | --- |
-| Java | 17 (CI: 17, 21, 25) |
+| Java | 17 |
 | Spring AI | 2.0.1 |
 | Spring Boot | 4.1.1 |
 | Presidio Analyzer | 2.2.364 |
 | Apache OpenNLP | 2.5.11 |
 | Gradle wrapper | 9.6.1 |
+
+CI는 Java 17, 21, 25에서 전체 테스트를 실행합니다. 외부 서비스가 필요한 Presidio 연동
+테스트와 JMH 스모크 테스트는 별도 CI 작업으로 실행합니다.
 
 Spring AI는 현재 `2.0.x` 계열 호환성을 유지하며, 신규 사용자에게는 `2.0.1`을
 권장합니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [English](README.md) | [한국어](README.ko.md) | [Documentation](https://ultramancode.github.io/spring-ai-privacy-guardrails/)
 
 <!-- i18n-source: README.md -->
-<!-- i18n-source-sha256: 27bb64080fbfa5c89aafcfc287d8e68de6f1ba47abd67e4a9213de31c49dfc16 -->
+<!-- i18n-source-sha256: a99edee37016e43d18ccf9bdd14cf098c980951e9c1b3647f34702435d85e562 -->
 
 <p align="center">
   <img src="docs/images/hero.svg" alt="Spring AI Privacy Guardrails 실행 경계" width="100%">
@@ -244,20 +244,17 @@ JMH 벤치마크는 라이브러리로 배포되지 않으며, 측정 대상과 
 
 ## 호환성과 상태
 
-| 구성 요소 | 호환 범위 / 검증 버전 |
+| 구성 요소 | 현재 검증 기준 |
 | --- | --- |
-| Java 기준 버전 | 17 |
-| Java 호환성 CI | 17, 21, 25 |
-| Spring AI 호환 계열 | 2.0.x |
-| Spring AI 권장 버전 | 2.0.1 |
+| Java | 17 (CI: 17, 21, 25) |
+| Spring AI | 2.0.1 |
 | Spring Boot | 4.1.1 |
 | Presidio Analyzer | 2.2.364 |
 | Apache OpenNLP | 2.5.11 |
 | Gradle wrapper | 9.6.1 |
 
-CI는 표의 현재 버전 조합을 검증하며, Spring AI는 2.0.x 계열 호환성도 확인합니다.
-Presidio 실제 연동 테스트와 OpenNLP 어댑터 테스트도 CI에 포함됩니다. 신규 사용자는
-표의 권장 및 검증 버전을 사용하세요.
+Spring AI는 현재 `2.0.x` 계열 호환성을 유지하며, 신규 사용자에게는 `2.0.1`을
+권장합니다.
 
 ## 상세 문서
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 [English](README.md) | [한국어](README.ko.md) | [Documentation](https://ultramancode.github.io/spring-ai-privacy-guardrails/)
 
 <!-- i18n-source: README.md -->
-<!-- i18n-source-sha256: cff246b3300beffe4df30d741eafc7cb0aea31c3437e2c4433318fc30e4c7c9c -->
+<!-- i18n-source-sha256: 27bb64080fbfa5c89aafcfc287d8e68de6f1ba47abd67e4a9213de31c49dfc16 -->
 
 <p align="center">
   <img src="docs/images/hero.svg" alt="Spring AI Privacy Guardrails 실행 경계" width="100%">
@@ -244,16 +244,20 @@ JMH 벤치마크는 라이브러리로 배포되지 않으며, 측정 대상과 
 
 ## 호환성과 상태
 
-| 구성 요소 | 검증한 버전 |
+| 구성 요소 | 호환 범위 / 검증 버전 |
 | --- | --- |
 | Java 기준 버전 | 17 |
 | Java 호환성 CI | 17, 21, 25 |
-| Spring AI | 2.0.0 |
-| Spring Boot | 4.1.0 |
+| Spring AI 호환 계열 | 2.0.x |
+| Spring AI 권장 버전 | 2.0.1 |
+| Spring Boot | 4.1.1 |
+| Presidio Analyzer | 2.2.364 |
+| Apache OpenNLP | 2.5.11 |
 | Gradle wrapper | 9.6.1 |
 
-CI는 Java 17, 21, 25에서 기본 검증을 실행하고, Java 21에서 Presidio 서비스와의 실제
-연동 테스트와 JMH 스모크 테스트를 별도로 실행합니다.
+CI는 표의 현재 버전 조합을 검증하며, Spring AI는 2.0.x 계열 호환성도 확인합니다.
+Presidio 실제 연동 테스트와 OpenNLP 어댑터 테스트도 CI에 포함됩니다. 신규 사용자는
+표의 권장 및 검증 버전을 사용하세요.
 
 ## 상세 문서
 

--- a/README.md
+++ b/README.md
@@ -256,21 +256,17 @@ in [Evaluation](docs/evaluation.md#jmh-benchmarks).
 
 ## Compatibility and Status
 
-| Component | Compatibility / verified version |
+| Component | Current verified baseline |
 | --- | --- |
-| Java baseline | 17 |
-| Java compatibility CI | 17, 21, 25 |
-| Spring AI compatibility line | 2.0.x |
-| Spring AI recommended version | 2.0.1 |
+| Java | 17 (CI: 17, 21, 25) |
+| Spring AI | 2.0.1 |
 | Spring Boot | 4.1.1 |
 | Presidio Analyzer | 2.2.364 |
 | Apache OpenNLP | 2.5.11 |
 | Gradle wrapper | 9.6.1 |
 
-CI verifies the current versions listed above and also checks compatibility
-within the Spring AI 2.0.x line. It includes live Presidio integration tests and
-OpenNLP adapter tests. New users should use the recommended and verified
-versions above.
+Spring AI maintains compatibility within the current `2.0.x` line, and `2.0.1`
+is recommended for new users.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -258,12 +258,15 @@ in [Evaluation](docs/evaluation.md#jmh-benchmarks).
 
 | Component | Current verified baseline |
 | --- | --- |
-| Java | 17 (CI: 17, 21, 25) |
+| Java | 17 |
 | Spring AI | 2.0.1 |
 | Spring Boot | 4.1.1 |
 | Presidio Analyzer | 2.2.364 |
 | Apache OpenNLP | 2.5.11 |
 | Gradle wrapper | 9.6.1 |
+
+CI runs the full test suite on Java 17, 21, and 25. Presidio integration tests,
+which require an external service, and JMH smoke tests run as separate CI jobs.
 
 Spring AI maintains compatibility within the current `2.0.x` line, and `2.0.1`
 is recommended for new users.

--- a/README.md
+++ b/README.md
@@ -256,17 +256,21 @@ in [Evaluation](docs/evaluation.md#jmh-benchmarks).
 
 ## Compatibility and Status
 
-| Component | Verified version |
+| Component | Compatibility / verified version |
 | --- | --- |
 | Java baseline | 17 |
 | Java compatibility CI | 17, 21, 25 |
-| Spring AI | 2.0.0 |
-| Spring Boot | 4.1.0 |
+| Spring AI compatibility line | 2.0.x |
+| Spring AI recommended version | 2.0.1 |
+| Spring Boot | 4.1.1 |
+| Presidio Analyzer | 2.2.364 |
+| Apache OpenNLP | 2.5.11 |
 | Gradle wrapper | 9.6.1 |
 
-CI runs the default verification on Java 17, 21, and 25. On Java 21, it
-separately runs live integration tests against a Presidio service and the JMH
-smoke tests.
+CI verifies the current versions listed above and also checks compatibility
+within the Spring AI 2.0.x line. It includes live Presidio integration tests and
+OpenNLP adapter tests. New users should use the recommended and verified
+versions above.
 
 ## Documentation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,8 +23,8 @@ the [Sample / Demo Guide](sample.md).
 The current release is verified with:
 
 - Java 17
-- Spring AI 2.0.0
-- Spring Boot 4.1.0
+- Spring AI 2.0.1
+- Spring Boot 4.1.1
 
 ## 1. Choose a Starter
 

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -3,7 +3,7 @@
 [English](../getting-started.md) | [한국어](getting-started.md)
 
 <!-- i18n-source: docs/getting-started.md -->
-<!-- i18n-source-sha256: fcd57eb5daf59910bc1d213a553cd2341e098bcd786d3e2e59d90c7a4483766c -->
+<!-- i18n-source-sha256: aa30565f1dd788f7a57f639dcf2830f844dcfc4a0917004f1a8b0b99b451b904 -->
 
 이 가이드는 기존 Spring AI 애플리케이션에 Spring AI Privacy Guardrails를
 추가해 모델, 도구, MCP 및 출력 경계에 개인정보 보호를 적용하는 기본 사용 방법을
@@ -26,8 +26,8 @@ JVM 내부에서 자체 NER 모델을 사용하려면 OpenNLP를, 애플리케�
 현재 릴리즈는 다음 환경에서 검증됩니다.
 
 - Java 17
-- Spring AI 2.0.0
-- Spring Boot 4.1.0
+- Spring AI 2.0.1
+- Spring Boot 4.1.1
 
 ## 1. 스타터 선택
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,9 @@ version=0.2.0-SNAPSHOT
 # javaVersion defines the source/bytecode baseline and default Java toolchain.
 # testJavaVersion optionally overrides the Java toolchain used for compatibility testing.
 javaVersion=17
-springBootVersion=4.1.0
-springAiVersion=2.0.0
-openNlpVersion=2.5.10
+springBootVersion=4.1.1
+springAiVersion=2.0.1
+openNlpVersion=2.5.11
 jacksonVersion=3.1.4
 assertjVersion=3.27.7
 junitVersion=6.0.3

--- a/samples/presidio/README.md
+++ b/samples/presidio/README.md
@@ -1,7 +1,7 @@
 # Presidio Sample
 
 This sample starts a local Presidio analyzer endpoint for integration testing.
-The Compose file pins Presidio Analyzer `2.2.363` and its multi-platform image
+The Compose file pins Presidio Analyzer `2.2.364` and its multi-platform image
 digest for reproducible smoke tests. Run the commands below from the repository
 root in a Linux shell.
 

--- a/samples/presidio/docker-compose.yml
+++ b/samples/presidio/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   presidio-analyzer:
-    image: ghcr.io/data-privacy-stack/presidio-analyzer:2.2.363@sha256:330c78c144eca0c554e4cf12ab7c05a21872dca63fe6f93d67f08741de30b62f
+    image: ghcr.io/data-privacy-stack/presidio-analyzer:2.2.364@sha256:ae8f6f111ac2f04e3fec552f7f80edd0dcbfa2dd69ee1b9e030475be31669885
     ports:
       - "127.0.0.1:5002:3000"
     healthcheck:

--- a/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyOutputAdvisorStreamTest.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/test/java/io/github/ultramancode/springai/privacy/springai/PrivacyOutputAdvisorStreamTest.java
@@ -29,6 +29,8 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.util.MimeTypeUtils;
 import reactor.core.publisher.Flux;
 
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -690,21 +692,6 @@ class PrivacyOutputAdvisorStreamTest {
                 "blocked",
                 new PrivacyResponseInspectionLimits(10, 100, 1, Duration.ofSeconds(1))
         );
-        Media unsupportedMedia = Media.builder()
-                .mimeType(MimeTypeUtils.APPLICATION_OCTET_STREAM)
-                .data(new Object())
-                .build();
-        StreamAdvisorChain unsupportedMediaChain = mock(StreamAdvisorChain.class);
-        when(unsupportedMediaChain.nextStream(any())).thenReturn(Flux.just(response(List.of(new Generation(
-                AssistantMessage.builder().media(List.of(unsupportedMedia)).build()
-        )))));
-        PrivacyOutputAdvisor unsupportedMediaAdvisor = new PrivacyOutputAdvisor(
-                service,
-                PrivacyOutputAction.TOKENIZE,
-                "blocked",
-                new PrivacyResponseInspectionLimits(10, 100, 100, Duration.ofSeconds(1))
-        );
-
         try (PrivacySession session = service.openSession()) {
             assertThatThrownBy(() -> protectStreamAtApplicationBoundary(
                     characterAdvisor, session.handle(), characterChain
@@ -734,8 +721,32 @@ class PrivacyOutputAdvisorStreamTest {
                             "code",
                             PrivacyFailureCode.RESPONSE_INSPECTION_LIMIT_EXCEEDED
                     );
+        }
+    }
+
+    @Test
+    void adviseStreamFailsClosedForUrlMediaData() throws MalformedURLException {
+        PrivacyService service = privacyService();
+        Media remoteMedia = Media.builder()
+                .mimeType(MimeTypeUtils.IMAGE_PNG)
+                .data(URI.create("https://example.invalid/media").toURL())
+                .build();
+        StreamAdvisorChain chain = mock(StreamAdvisorChain.class);
+        when(chain.nextStream(any())).thenReturn(Flux.just(response(List.of(new Generation(
+                AssistantMessage.builder().media(List.of(remoteMedia)).build()
+        )))));
+        PrivacyOutputAdvisor advisor = new PrivacyOutputAdvisor(
+                service,
+                PrivacyOutputAction.TOKENIZE,
+                "blocked",
+                new PrivacyResponseInspectionLimits(10, 100, 100, Duration.ofSeconds(1))
+        );
+
+        // URL-valued media data cannot be locally size-accounted without dereferencing it,
+        // so this representation fails closed without network access.
+        try (PrivacySession session = service.openSession()) {
             assertThatThrownBy(() -> protectStreamAtApplicationBoundary(
-                    unsupportedMediaAdvisor, session.handle(), unsupportedMediaChain
+                    advisor, session.handle(), chain
             ).collectList().block())
                     .isInstanceOf(PrivacyGuardrailException.class)
                     .hasFieldOrPropertyWithValue(


### PR DESCRIPTION
## Summary

This change updates the current Spring AI compatibility baseline to 2.0.1 and Spring Boot to 4.1.1 while retaining compatibility verification for Spring AI 2.0.0.

Java 17 CI also verifies compatibility with Spring AI 2.0.0, while the Spring AI 2.0.1 baseline continues to run across Java 17, 21, and 25.

The optional analyzer baselines are also refreshed to Presidio Analyzer 2.2.364 and Apache OpenNLP 2.5.11. The compatibility documentation now identifies Spring AI 2.0.x as the current compatibility line and recommends Spring AI 2.0.1
for new users.

Spring AI 2.0.1 changed the public `Media.Builder` data API, so the response inspection test is adapted to the supported media representations. Byte-backed media continues to verify the configured media-size limit, while URL-valued media verifies the existing fail-closed behavior without network access.

No project production code or public API is changed.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.