### PR TITLE
build: run Presidio live integration on Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
@@ -132,7 +132,7 @@ jobs:
             :spring-ai-privacy-guardrails-presidio:test \
             :spring-ai-privacy-guardrails-sample-demo:test \
             --tests '*Presidio*LiveIntegrationTest' \
-            -PtestJavaVersion=21 \
+            -PtestJavaVersion=17 \
             --rerun-tasks
 
       - name: Show Presidio logs


### PR DESCRIPTION
## Summary

Run the Presidio live integration job on Java 17 to align it with the project's minimum supported Java baseline.

No production code or public API is changed.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.