### PR TITLE
docs: improve bilingual documentation navigation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -4,13 +4,18 @@
 [![CI](https://github.com/ultramancode/spring-ai-privacy-guardrails/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ultramancode/spring-ai-privacy-guardrails/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-[English](README.md) | [한국어](README.ko.md) | [Documentation](https://ultramancode.github.io/spring-ai-privacy-guardrails/)
+[English](README.md) | [한국어](README.ko.md) | [문서](https://ultramancode.github.io/spring-ai-privacy-guardrails/ko/)
 
 <!-- i18n-source: README.md -->
-<!-- i18n-source-sha256: 6e1a421c9df07f5db7aec1f78d4b3e8ba1ca60a5776f88fea343e59c9b3817d9 -->
+<!-- i18n-source-sha256: 1fc0a4af07a224971ee690224992558adb3b3606ccae1408472c7971a0e51971 -->
 
 <p align="center">
   <img src="docs/images/hero.svg" alt="Spring AI Privacy Guardrails 실행 경계" width="100%">
+</p>
+
+<p align="center">
+  Spring 공식 블로그에서 소개:
+  <a href="https://spring.io/blog/2026/08/18/this-week-in-spring-august-18-2026/">This Week in Spring — August 18, 2026</a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 </p>
 
 <p align="center">
+  Featured on the Spring Blog:
+  <a href="https://spring.io/blog/2026/08/18/this-week-in-spring-august-18-2026/">This Week in Spring — August 18, 2026</a>
+</p>
+
+<p align="center">
   <strong>Watch the demo:</strong>
   <a href="https://youtu.be/IeeA5ogIX_I">English</a> ·
   <a href="https://youtu.be/vir-x78e9j8">한국어</a>

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ privacyBuild {
     }
 
     localizedDocument 'README.md', 'README.ko.md'
+    localizedDocument 'docs/index.md', 'docs/ko/index.md'
     localizedDocument 'docs/architecture.md', 'docs/ko/architecture.md'
     localizedDocument 'docs/configuration.md', 'docs/ko/configuration.md'
     localizedDocument 'docs/evaluation.md', 'docs/ko/evaluation.md'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-[English](architecture.md) | [한국어](ko/architecture.md)
+**English** | [한국어](ko/architecture.md)
 
 ## Responsibility Boundary
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration and Usage
 
-[English](configuration.md) | [한국어](ko/configuration.md)
+**English** | [한국어](ko/configuration.md)
 
 This document is the comprehensive application-facing reference for Spring AI
 Privacy Guardrails. The base Spring Boot starter provides the `core` module and

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,6 +1,11 @@
+---
+hide:
+  - footer
+---
+
 # Evaluation and Benchmarks
 
-[English](evaluation.md) | [한국어](ko/evaluation.md)
+**English** | [한국어](ko/evaluation.md)
 
 This repository includes a regression test for the demo analyzer,
 privacy-boundary tests, and JMH benchmarks. The regression test checks detection

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-[English](getting-started.md) | [한국어](ko/getting-started.md)
+**English** | [한국어](ko/getting-started.md)
 
 This guide shows the basic path for adding Spring AI Privacy Guardrails to an
 existing Spring AI application and applying privacy protection across model,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Spring AI Privacy Guardrails
 
+**English** | [한국어](ko/index.md)
+
 ![Spring AI Privacy Guardrails execution boundary](images/hero.svg)
 
 Keep detected PII out of the model. Reveal only what each trusted tool needs.
@@ -8,6 +10,9 @@ Protect every tool result before it leaves the tool boundary.
 Detection answers **what text is sensitive**. Spring AI Privacy Guardrails
 enforces **where the original value may travel** across model, tool, output,
 and request-lifecycle boundaries.
+
+Featured on the Spring Blog:
+[This Week in Spring — August 18, 2026](https://spring.io/blog/2026/08/18/this-week-in-spring-august-18-2026/).
 
 ## See It in Action
 
@@ -43,4 +48,4 @@ evidence at the model and tool boundaries.
 
 See the [Sample / Demo Guide](sample.md) for the Inspector workflow and the
 [full sample application guide](https://github.com/ultramancode/spring-ai-privacy-guardrails/blob/main/samples/spring-ai-demo/README.md)
-for optional profiles and integration examples.
+for Presidio and OpenNLP profiles and integration examples.

--- a/docs/ko/architecture.md
+++ b/docs/ko/architecture.md
@@ -1,9 +1,9 @@
 # 아키텍처
 
-[English](../architecture.md) | [한국어](architecture.md)
+[English](../architecture.md) | **한국어**
 
 <!-- i18n-source: docs/architecture.md -->
-<!-- i18n-source-sha256: 7cefceefe2799e4e372c7491b3d8b0b4dd699a96976763283f834a092ab00c11 -->
+<!-- i18n-source-sha256: 3e33757cba7ee312a17c4bb5d2180201f1f1e7ceee070e28a2f29898703651d6 -->
 
 ## 책임 범위
 

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -1,9 +1,9 @@
 # 설정과 사용법
 
-[English](../configuration.md) | [한국어](configuration.md)
+[English](../configuration.md) | **한국어**
 
 <!-- i18n-source: docs/configuration.md -->
-<!-- i18n-source-sha256: ce9298b47dcedbcd797f55614d4dd89f8727066c9ee7df574cd67dd571ae413f -->
+<!-- i18n-source-sha256: 65f41de3537c276c75aac6f02ef1fb8b914415dfc63cf4bdb0e0b30dc32c1fb4 -->
 
 이 문서는 Spring AI Privacy Guardrails를 사용하는 애플리케이션을 위한 종합
 참고 문서입니다. 기본 Spring Boot 스타터는 `core` 모듈과 Spring AI 통합 경계를

--- a/docs/ko/evaluation.md
+++ b/docs/ko/evaluation.md
@@ -1,9 +1,9 @@
 # 평가와 벤치마크
 
-[English](../evaluation.md) | [한국어](evaluation.md)
+[English](../evaluation.md) | **한국어**
 
 <!-- i18n-source: docs/evaluation.md -->
-<!-- i18n-source-sha256: 33949a0ca4fc3dcae1820950db8791d5dd6fc84c408ed6aab2b5591f4d3c3a63 -->
+<!-- i18n-source-sha256: 7959e7e34ca5d266809bf9d10805d7ee375957ba904afc792cfaf9bc060ec27d -->
 
 이 저장소에는 데모 분석기의 회귀 테스트, 개인정보 보호 경계 테스트와 JMH 벤치마크가
 포함되어 있습니다. 회귀 테스트는 탐지 결과를, 경계 테스트는 정책 적용을, JMH 벤치마크는

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -1,9 +1,9 @@
 # 시작하기
 
-[English](../getting-started.md) | [한국어](getting-started.md)
+[English](../getting-started.md) | **한국어**
 
 <!-- i18n-source: docs/getting-started.md -->
-<!-- i18n-source-sha256: aa30565f1dd788f7a57f639dcf2830f844dcfc4a0917004f1a8b0b99b451b904 -->
+<!-- i18n-source-sha256: a95496800cf193960f77713fb0ccc8a17be3af576fb43d0008b7343d8ae2e525 -->
 
 이 가이드는 기존 Spring AI 애플리케이션에 Spring AI Privacy Guardrails를
 추가해 모델, 도구, MCP 및 출력 경계에 개인정보 보호를 적용하는 기본 사용 방법을

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -1,0 +1,59 @@
+---
+hide:
+  - footer
+---
+
+# Spring AI Privacy Guardrails
+
+[English](../index.md) | **한국어**
+
+<!-- i18n-source: docs/index.md -->
+<!-- i18n-source-sha256: a670bb0c5f213b5f51138e4f7e06bb35f2cb55da9df5203d741e4506e5b65489 -->
+
+![Spring AI Privacy Guardrails 실행 경계](../images/hero.svg)
+
+탐지된 개인정보가 모델에 전달되지 않도록 보호합니다. 각 도구에는 정책이 허용한 원문만
+공개합니다. 모든 도구 결과는 도구 경계를 벗어나기 전에 다시 보호합니다.
+
+분석기는 **보호 대상 정보가 포함된 텍스트를 식별합니다**. Spring AI Privacy Guardrails는
+모델·도구·출력 및 요청 수명 주기 경계에서 **원문 값이 어디까지 이동할 수 있는지**를
+통제합니다.
+
+Spring 공식 블로그에서 소개:
+[This Week in Spring — August 18, 2026](https://spring.io/blog/2026/08/18/this-week-in-spring-august-18-2026/).
+
+## 직접 확인하기
+
+Privacy Boundary Inspector는 Local Tool, RAG 및 MCP 실행 중 샘플 백엔드가 기록한
+경계별 보호 상태를 보여줍니다.
+
+![Local Tool, RAG 및 MCP 실행 중 기록된 경계별 보호 상태를 보여주는 Privacy Boundary Inspector](../images/privacy-boundary-inspector-demo-ko.gif)
+
+전체 Inspector 흐름은 [샘플 / 데모 가이드](sample.md)를 참고하세요.
+
+## 참고 문서
+
+| 가이드 | 다루는 내용 |
+| --- | --- |
+| [시작하기](getting-started.md) | 스타터 선택, 기본 설정과 모델·도구·MCP·출력 보호 |
+| [샘플 / 데모 가이드](sample.md) | Inspector 시나리오, 런타임 엔드포인트, 언어별 동작과 경계별 보호 상태 |
+| [설정과 사용법](configuration.md) | 스타터, 분석기, 출력 정책, 도구 공개와 처리 제한 |
+| [아키텍처](architecture.md) | 모듈 경계, 요청 세션, 탐지 결과 해석과 실행 수명 주기 |
+| [위협 모델](threat-model.md) | 보호 대상, 신뢰 경계, 통제, 한계와 별도 관리 영역 |
+| [평가와 벤치마크](evaluation.md) | 경계 테스트, 재현 가능한 분석기 기준선과 프로젝트 벤치마크 |
+
+## 샘플 실행
+
+샘플은 항상 같은 결과를 반환하는 로컬 `ChatModel`을 사용하므로 클라우드 API 키가
+필요하지 않습니다.
+
+```bash
+./gradlew :spring-ai-privacy-guardrails-sample-demo:run
+```
+
+`http://127.0.0.1:8080`을 열어 모델 및 도구 경계에서 Local Tool, RAG, MCP의 실제
+보호 상태를 확인할 수 있습니다.
+
+Inspector 흐름은 [샘플 / 데모 가이드](sample.md), Presidio·OpenNLP 구성과 통합 예제는
+[전체 샘플 애플리케이션 가이드](https://github.com/ultramancode/spring-ai-privacy-guardrails/blob/main/samples/spring-ai-demo/README.ko.md)를
+참고하세요.

--- a/docs/ko/sample.md
+++ b/docs/ko/sample.md
@@ -1,9 +1,9 @@
 # 샘플 / 데모 가이드
 
-[English](../sample.md) | [한국어](sample.md)
+[English](../sample.md) | **한국어**
 
 <!-- i18n-source: docs/sample.md -->
-<!-- i18n-source-sha256: 930961a32c7cfe45a9c11352923b75b776bf7993dd3217010833417b35fea5e0 -->
+<!-- i18n-source-sha256: c3fb41c77a5558724417f11b23b0244ba95678af865288e99e7f8664610c5dd1 -->
 
 실행 가능한 샘플은 항상 같은 결과를 반환하는 로컬 `ChatModel`, 메모리 내 RAG 구성 요소,
 루프백 MCP 서버를 사용하므로 클라우드 자격 증명이 필요하지 않습니다. **Privacy

--- a/docs/ko/threat-model.md
+++ b/docs/ko/threat-model.md
@@ -1,9 +1,9 @@
 # 위협 모델
 
-[English](../threat-model.md) | [한국어](threat-model.md)
+[English](../threat-model.md) | **한국어**
 
 <!-- i18n-source: docs/threat-model.md -->
-<!-- i18n-source-sha256: 8fb2a9124d8a83633cbefe5fc0df5636df7cffdc85cf9c963a261ad0de82f24d -->
+<!-- i18n-source-sha256: 997d483a14a45ec6157a2545c3fbe68f06735de8fdef4ed22d9a81f768983888 -->
 
 ## 보호 대상
 

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -1,6 +1,6 @@
 # Sample / Demo Guide
 
-[English](sample.md) | [한국어](ko/sample.md)
+**English** | [한국어](ko/sample.md)
 
 The runnable sample uses a deterministic local `ChatModel`, in-memory RAG
 components, and a loopback MCP server. No cloud credentials are required. Its

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-[English](threat-model.md) | [한국어](ko/threat-model.md)
+**English** | [한국어](ko/threat-model.md)
 
 ## Protected Assets
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -23,6 +23,7 @@ nav = [
     { "Evaluation" = "evaluation.md" },
   ] },
   { "한국어" = [
+    { "홈" = "ko/index.md" },
     { "시작하기" = "ko/getting-started.md" },
     { "샘플 / 데모 가이드" = "ko/sample.md" },
     { "설정과 사용법" = "ko/configuration.md" },


### PR DESCRIPTION
## Summary

This change adds the project's mention in the Spring Blog's [*This Week in Spring — August 18, 2026*](https://spring.io/blog/2026/08/18/this-week-in-spring-august-18-2026/) to the English and Korean documentation entry points.

It also adds a Korean documentation home and aligns English and Korean language links across the root READMEs and reference pages.

Cross-language previous/next navigation is hidden at the English and Korean documentation boundary to keep navigation within the selected language.

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.