### PR TITLE
fix: bound direct core text inputs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -561,7 +561,9 @@ caused by excessively large or complex inputs. The main maxima are:
 
 | Scope | Maximum |
 | --- | ---: |
-| One text or JSON payload processed at a Spring AI boundary, or the aggregate content of one `core` value tree | 1,000,000 characters |
+| One direct `core` text input analyzed automatically or with caller-supplied spans | 1,000,000 UTF-16 code units |
+| One text or JSON payload processed at a Spring AI boundary | 1,000,000 UTF-16 code units |
+| Aggregate content of one `core` value tree | 1,000,000 UTF-16 code units |
 | JSON or value-tree nodes | 100,000 |
 | JSON or value-tree nesting levels | 128 |
 | Output produced after transformation | 8,000,000 characters |

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -3,7 +3,7 @@
 [English](../configuration.md) | **한국어**
 
 <!-- i18n-source: docs/configuration.md -->
-<!-- i18n-source-sha256: 07b16d27791faf4a39d5a1f8909c4b1f3f23d13fc14bb7db0445c667bab90657 -->
+<!-- i18n-source-sha256: 65e3e20843d8e73c13a563a4da5794290fcdea24fcc9bc559a662984f2de11e9 -->
 
 이 문서는 Spring AI Privacy Guardrails를 사용하는 애플리케이션을 위한 종합
 참고 문서입니다. 기본 Spring Boot 스타터는 `core` 모듈과 Spring AI 통합 경계를
@@ -535,7 +535,9 @@ spring:
 
 | 범위 | 최대치 |
 | --- | ---: |
-| Spring AI 경계에서 처리하는 단일 텍스트·JSON 페이로드와 `core` 값 트리의 전체 콘텐츠 | 1,000,000자 |
+| 자동 분석 또는 호출자 제공 span과 함께 처리하는 단일 `core` 직접 텍스트 입력 | UTF-16 코드 유닛 1,000,000개 |
+| Spring AI 경계에서 처리하는 단일 텍스트·JSON 페이로드 | UTF-16 코드 유닛 1,000,000개 |
+| 단일 `core` 값 트리의 전체 콘텐츠 | UTF-16 코드 유닛 1,000,000개 |
 | JSON 또는 값 트리의 노드 수 | 100,000개 |
 | JSON 또는 값 트리의 중첩 단계 | 128 |
 | 변환 후 생성되는 출력 | 8,000,000자 |

--- a/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PiiAnalysisCoordinator.java
+++ b/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PiiAnalysisCoordinator.java
@@ -81,6 +81,7 @@ final class PiiAnalysisCoordinator {
     }
 
     PiiAnalysisResult analyzeDetailed(String text) {
+        requireTextInputWithinLimit(text);
         if (text == null || text.isBlank()) {
             return new PiiAnalysisResult(List.of(), Set.of(), List.of());
         }
@@ -144,6 +145,7 @@ final class PiiAnalysisCoordinator {
     }
 
     List<ResolvedPiiSpan> resolveSuppliedSpans(String text, List<PiiSpan> spans) {
+        requireTextInputWithinLimit(text);
         requireSuppliedSpanCount(spans);
         return this.evidenceResolver.resolveSuppliedSpans(text, spans, this.options);
     }
@@ -320,6 +322,16 @@ final class PiiAnalysisCoordinator {
                     PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED,
                     PrivacyPhase.ANALYSIS,
                     "Caller-supplied PII spans exceeded the bounded processing limit"
+            );
+        }
+    }
+
+    private static void requireTextInputWithinLimit(String text) {
+        if (text != null && text.length() > PrivacyService.MAX_TEXT_INPUT_CHARACTERS) {
+            throw new PrivacyGuardrailException(
+                    PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED,
+                    PrivacyPhase.ANALYSIS,
+                    "Privacy text input exceeded the bounded processing limit"
             );
         }
     }

--- a/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PiiAnalysisCoordinator.java
+++ b/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PiiAnalysisCoordinator.java
@@ -326,7 +326,7 @@ final class PiiAnalysisCoordinator {
         }
     }
 
-    private static void requireTextInputWithinLimit(String text) {
+    static void requireTextInputWithinLimit(String text) {
         if (text != null && text.length() > PrivacyService.MAX_TEXT_INPUT_CHARACTERS) {
             throw new PrivacyGuardrailException(
                     PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED,

--- a/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PrivacyService.java
+++ b/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PrivacyService.java
@@ -6,6 +6,9 @@ import java.util.Set;
 /** Public facade for PII analysis, transformation, and privacy session lifecycle. */
 public final class PrivacyService {
 
+    /** Hard maximum UTF-16 code units accepted for analysis or supplied-span resolution. */
+    public static final int MAX_TEXT_INPUT_CHARACTERS = 1_000_000;
+
     /** Hard maximum for text produced by a privacy transformation that changes content. */
     public static final int MAX_TRANSFORMED_TEXT_CHARACTERS = 8_000_000;
 

--- a/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PrivacyTextTransformer.java
+++ b/spring-ai-privacy-guardrails-core/src/main/java/io/github/ultramancode/springai/privacy/core/PrivacyTextTransformer.java
@@ -40,6 +40,7 @@ final class PrivacyTextTransformer {
     }
 
     String redact(String text) {
+        PiiAnalysisCoordinator.requireTextInputWithinLimit(text);
         if (text == null || text.isBlank()) {
             return text;
         }
@@ -60,6 +61,7 @@ final class PrivacyTextTransformer {
     }
 
     String redact(String text, PrivacyContext context) {
+        PiiAnalysisCoordinator.requireTextInputWithinLimit(text);
         if (text == null || text.isBlank()) {
             return text;
         }
@@ -72,6 +74,7 @@ final class PrivacyTextTransformer {
     }
 
     boolean containsPii(String text, PrivacyContext context) {
+        PiiAnalysisCoordinator.requireTextInputWithinLimit(text);
         if (text == null || text.isBlank()) {
             return false;
         }

--- a/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacyProcessingLimitsTest.java
+++ b/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacyProcessingLimitsTest.java
@@ -1,5 +1,6 @@
 package io.github.ultramancode.springai.privacy.core;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
 import java.util.AbstractList;
@@ -51,6 +52,18 @@ class PrivacyProcessingLimitsTest {
             assertThat(failure.code()).isEqualTo(PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED);
             assertThat(failure.phase()).isEqualTo(PrivacyPhase.ANALYSIS);
         });
+    }
+
+    @Test
+    void automaticTextOperationsRejectOversizedWhitespace() {
+        PrivacyService service = new PrivacyService(List.of(), PiiAnalysisOptions.defaults());
+        String oversizedWhitespace = " ".repeat(PrivacyService.MAX_TEXT_INPUT_CHARACTERS + 1);
+
+        try (PrivacySession session = service.openSession()) {
+            assertAnalysisPayloadLimitExceeded(() -> service.redact(oversizedWhitespace));
+            assertAnalysisPayloadLimitExceeded(() -> service.redact(session.handle(), oversizedWhitespace));
+            assertAnalysisPayloadLimitExceeded(() -> service.containsPii(session.handle(), oversizedWhitespace));
+        }
     }
 
     @Test
@@ -222,6 +235,14 @@ class PrivacyProcessingLimitsTest {
                 return PiiAnalyzer.MAX_RESULT_SPANS + 1;
             }
         };
+    }
+
+    private static void assertAnalysisPayloadLimitExceeded(ThrowingCallable operation) {
+        assertThatThrownBy(operation)
+                .isInstanceOfSatisfying(PrivacyGuardrailException.class, failure -> {
+                    assertThat(failure.code()).isEqualTo(PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED);
+                    assertThat(failure.phase()).isEqualTo(PrivacyPhase.ANALYSIS);
+                });
     }
 
     private static PiiAnalyzer namedAnalyzer(String providerId, PiiAnalyzer delegate) {

--- a/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacyProcessingLimitsTest.java
+++ b/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacyProcessingLimitsTest.java
@@ -40,10 +40,13 @@ class PrivacyProcessingLimitsTest {
     @Test
     void callerSuppliedSpansRejectOversizedSourceText() {
         PrivacyService service = new PrivacyService(List.of(), PiiAnalysisOptions.defaults());
+        int oversizedLength = PrivacyService.MAX_TEXT_INPUT_CHARACTERS + 1;
+        // A range failure here would show that span resolution ran before the text limit check.
+        PiiSpan outOfRangeSpan = new PiiSpan("SECRET", oversizedLength, oversizedLength + 1, 1.0);
 
         assertThatThrownBy(() -> service.redact(
-                "x".repeat(PrivacyService.MAX_TEXT_INPUT_CHARACTERS + 1),
-                List.of(new PiiSpan("SECRET", 0, 1, 1.0))
+                "x".repeat(oversizedLength),
+                List.of(outOfRangeSpan)
         )).isInstanceOfSatisfying(PrivacyGuardrailException.class, failure -> {
             assertThat(failure.code()).isEqualTo(PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED);
             assertThat(failure.phase()).isEqualTo(PrivacyPhase.ANALYSIS);

--- a/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacyProcessingLimitsTest.java
+++ b/spring-ai-privacy-guardrails-core/src/test/java/io/github/ultramancode/springai/privacy/core/PrivacyProcessingLimitsTest.java
@@ -8,11 +8,47 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PrivacyProcessingLimitsTest {
+
+    @Test
+    void directTextInputEnforcesTheBoundaryBeforeAnalyzerInvocation() {
+        AtomicInteger analyzerCalls = new AtomicInteger();
+        PiiAnalyzer analyzer = (text, options) -> {
+            analyzerCalls.incrementAndGet();
+            return List.of();
+        };
+        PrivacyService service = new PrivacyService(List.of(analyzer), PiiAnalysisOptions.defaults());
+
+        assertThat(service.analyze("x".repeat(PrivacyService.MAX_TEXT_INPUT_CHARACTERS)))
+                .isEmpty();
+        assertThat(analyzerCalls).hasValue(1);
+
+        assertThatThrownBy(() -> service.analyze(
+                "x".repeat(PrivacyService.MAX_TEXT_INPUT_CHARACTERS + 1)
+        )).isInstanceOfSatisfying(PrivacyGuardrailException.class, failure -> {
+            assertThat(failure.code()).isEqualTo(PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED);
+            assertThat(failure.phase()).isEqualTo(PrivacyPhase.ANALYSIS);
+        });
+        assertThat(analyzerCalls).hasValue(1);
+    }
+
+    @Test
+    void callerSuppliedSpansRejectOversizedSourceText() {
+        PrivacyService service = new PrivacyService(List.of(), PiiAnalysisOptions.defaults());
+
+        assertThatThrownBy(() -> service.redact(
+                "x".repeat(PrivacyService.MAX_TEXT_INPUT_CHARACTERS + 1),
+                List.of(new PiiSpan("SECRET", 0, 1, 1.0))
+        )).isInstanceOfSatisfying(PrivacyGuardrailException.class, failure -> {
+            assertThat(failure.code()).isEqualTo(PrivacyFailureCode.PAYLOAD_LIMIT_EXCEEDED);
+            assertThat(failure.phase()).isEqualTo(PrivacyPhase.ANALYSIS);
+        });
+    }
 
     @Test
     void detokenizeScansThousandsOfMappingsWithoutSearchingForEachMapping() {

--- a/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyJsonPayloadTransformer.java
+++ b/spring-ai-privacy-guardrails-spring-ai/src/main/java/io/github/ultramancode/springai/privacy/springai/PrivacyJsonPayloadTransformer.java
@@ -19,7 +19,7 @@ import java.util.function.UnaryOperator;
 /** Orchestrates JSON-aware privacy actions with safe plain-text fallback. */
 final class PrivacyJsonPayloadTransformer {
 
-    static final int MAX_PAYLOAD_CHARACTERS = 1_000_000;
+    static final int MAX_PAYLOAD_CHARACTERS = PrivacyService.MAX_TEXT_INPUT_CHARACTERS;
     static final int MAX_STRING_SCALAR_CHARACTERS =
             PrivacyService.MAX_VALUE_TREE_STRING_CHARACTERS;
     static final int MAX_NUMBER_LEXEME_CHARACTERS =


### PR DESCRIPTION
## Summary

Apply the existing Spring AI payload-size limit to direct core text operations.

Oversized text is rejected before analyzers run or caller-supplied spans are resolved. The Spring AI boundary keeps its current behavior, with both modules using the same limit.

Add regression tests for the boundary and validation order.

## Related Issue

Closes #35

## Verification

- `./gradlew clean check` with Java 17

## Checklist

- [x] I added a `Signed-off-by` line to each commit (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] I added focused tests when behavior changed and ran the relevant checks locally.
- [x] I updated any affected documentation and configuration examples.